### PR TITLE
[primer-components] Add Storybook.js Nix package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist/
 
 # eslint
 .eslintcache
+
+# Storybook.js
+storybook-static/

--- a/packages/primer-components/package.json
+++ b/packages/primer-components/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },


### PR DESCRIPTION
Note that in order to make this work, I had to promote the packages in
`peerDependencies` ("react" and "react-dom") to `dependencies`. This
is due to the fact that yarn2nix doesn't know about
`peerDependencies`, and therefore doesn't make them available at
package build time in the Nix expression.

This doesn't appear to cause any problems in either our Yarn build
system, nor with the Nix packages, but if we ever do publish these
packages, we should probably revisit this, as technically, we could
cause problems for downstream consumers of the
"@hackworthltd/primer-components package"".