### PR TITLE
fix: The TypeScript language server also needs the compiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "devDependencies": {
     "prettier": "^2.4.1",
+    "typescript": "^4.5.2",
     "typescript-eslint-language-service": "^4.1.5",
     "typescript-language-server": "^0.7.1",
     "unified-language-server": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12561,7 +12561,7 @@ typescript@^2.9.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^4.3.2, typescript@^4.4.3:
+typescript@^4.3.2, typescript@^4.4.3, typescript@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
   integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==


### PR DESCRIPTION
This is probably already available in each workspace, but it doesn't
hurt to add it at top level.