### PR TITLE
fix: Change storybook websocket to non-privileged port

### DIFF
--- a/packages/primer-components/.storybook/main.js
+++ b/packages/primer-components/.storybook/main.js
@@ -19,7 +19,7 @@ module.exports = {
       config.server.https = false;
       config.server.host = true;
       config.server.hmr = {
-        port: 443,
+        port: 6443,
         protocol: "ws",
       };
     }


### PR DESCRIPTION
On Linux, non-root processes cannot bind to ports below 1024. We
shouldn't require elevated permissions to run a local storybook!