### PR TITLE
fix: Fix the TypeScript build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "yaml-language-server": "^1.2.0"
   },
   "scripts": {
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "build": "yarn compile",
+    "compile": "tsc --build",
+    "watch": "tsc --build --watch"
   },
   "dependencies": {
     "npm-run-all": "^4.1.5"

--- a/packages/primer-app/package.json
+++ b/packages/primer-app/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "private": true,
+  "main": "src/main.tsx",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -11,12 +12,12 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
+    "@hackworthltd/primer-components": "*",
+    "@hackworthltd/primer-types": "*",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },
   "devDependencies": {
-    "@hackworthltd/primer-components": "^0.2.0",
-    "@hackworthltd/primer-types": "^0.2.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.31.2",

--- a/packages/primer-app/tsconfig.json
+++ b/packages/primer-app/tsconfig.json
@@ -1,42 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
+    "outDir": "./dist",
     "jsx": "react-jsx",
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "alwaysStrict": true,
-    "exactOptionalPropertyTypes": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "plugins": [
-      {
-        "name": "typescript-eslint-language-service"
-      }
-    ],
-    "noEmit": true,
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/primer-components/package.json
+++ b/packages/primer-components/package.json
@@ -4,14 +4,7 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": true,
   "sideEffects": false,
-  "module": "./dist/index.es.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.es.js"
-    },
-    "./style.css": "./dist/style.css"
-  },
+  "main": "src/index.ts",
   "scripts": {
     "build": "vite build",
     "storybook": "start-storybook -p 6006",
@@ -21,6 +14,7 @@
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {
+    "@hackworthltd/primer-types": "*",
     "@dicebear/avatars": "^4.9.1",
     "@dicebear/avatars-bottts-sprites": "^4.9.1",
     "@dicebear/avatars-identicon-sprites": "^4.9.1",
@@ -31,7 +25,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",
-    "@hackworthltd/primer-types": "^0.2.0",
     "@headlessui/react": "^1.4.1",
     "@heroicons/react": "^1.0.4",
     "@honkhonk/vite-plugin-svgr": "^1.1.0",

--- a/packages/primer-components/src/ActionButtonList/ActionButtonList.tsx
+++ b/packages/primer-components/src/ActionButtonList/ActionButtonList.tsx
@@ -2,7 +2,7 @@ import "@/index.css";
 
 import { ActionButton, ActionButtonProps } from "@/ActionButton/ActionButton";
 
-interface ActionButtonListProps {
+export interface ActionButtonListProps {
   actions: ActionButtonProps[];
 }
 

--- a/packages/primer-components/src/BinaryTreePlaceholder/BinaryTreePlaceholder.tsx
+++ b/packages/primer-components/src/BinaryTreePlaceholder/BinaryTreePlaceholder.tsx
@@ -2,7 +2,7 @@ import "@/index.css";
 
 import BinaryTreeSvg from "./binary-tree.svg?component";
 
-interface BinaryTreePlaceholderProps {
+export interface BinaryTreePlaceholderProps {
   className?: string;
 }
 

--- a/packages/primer-components/src/Logo/Logo.tsx
+++ b/packages/primer-components/src/Logo/Logo.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 
 import LogoSvg from "./logo.svg?component";
 
-interface LogoProps {
+export interface LogoProps {
   size?: "sm" | "md" | "lg" | "xl";
 }
 

--- a/packages/primer-components/src/SessionList/SessionList.tsx
+++ b/packages/primer-components/src/SessionList/SessionList.tsx
@@ -3,7 +3,7 @@ import "@/index.css";
 import { SessionMeta } from "@hackworthltd/primer-types";
 import { SessionPreview } from "@/SessionPreview/SessionPreview";
 
-interface SessionListProps {
+export interface SessionListProps {
   sessions: SessionMeta[];
 }
 

--- a/packages/primer-components/src/SessionPreview/SessionPreview.tsx
+++ b/packages/primer-components/src/SessionPreview/SessionPreview.tsx
@@ -3,7 +3,7 @@ import "@/index.css";
 import { SessionMeta } from "@hackworthltd/primer-types";
 import { BinaryTreePlaceholder } from "@/BinaryTreePlaceholder/BinaryTreePlaceholder";
 
-interface SessionPreviewProps {
+export interface SessionPreviewProps {
   session: SessionMeta;
 }
 

--- a/packages/primer-components/tsconfig.json
+++ b/packages/primer-components/tsconfig.json
@@ -1,47 +1,14 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationDir": "./dist",
-    "declarationMap": true,
-    "sourceMap": true,
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
+    "outDir": "./dist",
     "jsx": "react-jsx",
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "alwaysStrict": true,
-    "exactOptionalPropertyTypes": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "plugins": [
-      {
-        "name": "typescript-eslint-language-service"
-      }
-    ],
     "types": ["@honkhonk/vite-plugin-svgr/client"],
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "references": [{ "path": "../primer-types" }]
 }

--- a/packages/primer-types/package.json
+++ b/packages/primer-types/package.json
@@ -4,13 +4,7 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": true,
   "sideEffects": false,
-  "module": "./dist/index.es.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.es.js"
-    }
-  },
+  "main": "src/index.ts",
   "scripts": {
     "build": "vite build",
     "lint": "eslint .",

--- a/packages/primer-types/tsconfig.json
+++ b/packages/primer-types/tsconfig.json
@@ -1,42 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationDir": "./dist",
-    "declarationMap": true,
-    "sourceMap": true,
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "alwaysStrict": true,
-    "exactOptionalPropertyTypes": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "plugins": [
-      {
-        "name": "typescript-eslint-language-service"
-      }
-    ],
-    "baseUrl": "./",
+    "outDir": "./dist",
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "alwaysStrict": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "plugins": [
+      {
+        "name": "typescript-eslint-language-service"
+      }
+    ],
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "files": [],
+  "include": [],
   "references": [
     {
-      "path": "primer-app"
+      "path": "./packages/primer-app"
     },
     {
-      "path": "primer-components"
+      "path": "./packages/primer-components",
+      "name": "@hackworthltd/primer-components"
     },
-    { "path": "primer-types" }
+    {
+      "path": "./packages/primer-types",
+      "name": "@hackworthltd/primer-types"
+    }
   ]
 }


### PR DESCRIPTION
The project now builds with TypeScript (previously it did not). You
can test this for yourself via `tsc --build` or `yarn build` from the
top-level directory. However, this is only useful as a sanity check.
We don't use `tsc --build` to build our app, we use Vite, which
doesn't use `tsc` except for type-checking.

In any case, this means the project is now correctly configured for
use with TypeScript, which will hopefully mean that we don't run into
trouble with tooling that uses `tsc` and friends.

Note that the small detail that made all of these changes fall into
place was adding `"main": "src/index.ts"` or similar to each package's
`package.json` file. Without this, `tsc` could not resolve type
imports across local packages; e.g., `import * from
"@hackworthltd/primer-types"` would fail.

One nice fringe benefit of all this refactoring is that we can share
the bulk our TypeScript config across all packages, so we now have
better DRY.

Note that I've also fixed a few missing exports that were revealed by
building the entire project (i.e., all workspaces) with `tsc`.