### PR TITLE
fix: Fix the Vite sourcemap generation.

### DIFF
--- a/packages/primer-app/vite.config.ts
+++ b/packages/primer-app/vite.config.ts
@@ -17,8 +17,6 @@ export default defineConfig({
     OptimizationPersist(),
   ],
 
-  sourcemap: true,
-
   // Don't write to node_modules, in case someday we can get it from Nix.
   cacheDir: ".vite",
 
@@ -35,5 +33,9 @@ export default defineConfig({
   esbuild: {
     jsxFactory: "_jsx",
     jsxInject: `import { createElement as _jsx } from "react"`,
+  },
+
+  build: {
+    sourcemap: true,
   },
 });

--- a/packages/primer-components/vite.config.ts
+++ b/packages/primer-components/vite.config.ts
@@ -25,8 +25,6 @@ export default defineConfig({
     OptimizationPersist(),
   ],
 
-  sourcemap: true,
-
   // Don't write to node_modules, in case someday we can get it from Nix.
   cacheDir: ".vite",
 
@@ -45,8 +43,10 @@ export default defineConfig({
     jsxInject: `import { createElement as _jsx } from "react"`,
   },
 
-  // Library mode settings.
   build: {
+    sourcemap: true,
+
+    // Library mode settings.
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: name,

--- a/packages/primer-types/vite.config.ts
+++ b/packages/primer-types/vite.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
     OptimizationPersist(),
   ],
 
-  sourcemap: true,
-
   // Don't write to node_modules, in case someday we can get it from Nix.
   cacheDir: ".vite",
 
@@ -34,8 +32,10 @@ export default defineConfig({
     },
   },
 
-  // Library mode settings.
   build: {
+    sourcemap: true,
+
+    // Library mode settings.
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: name,


### PR DESCRIPTION
Turns out I put the directive in the wrong location in the Vite
config. You'd think it would have complained, but nope.