### PR TITLE
ci: Slow down Dependabot's npm update frequency to once per week.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
 - package-ecosystem: "npm"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   reviewers:
     - "dhess"
   commit-message:


### PR DESCRIPTION
Fixes https://github.com/hackworthltd/primer-app/issues/176