### PR TITLE
ci: Use a separate pipeline for Chromatic deployments.

### DIFF
--- a/.buildkite/pipeline.chromatic.yaml
+++ b/.buildkite/pipeline.chromatic.yaml
@@ -1,0 +1,6 @@
+agents:
+  chromatic: "true"
+
+steps:
+  - label: ":chromatic: Deploy Storybook to Chromatic"
+    command: nix run .#deploy-to-chromatic

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -10,7 +10,14 @@ steps:
           post-build-hook:
             /run/current-system/sw/bin/buildkite-private-post-build-hook
   - wait
-  - label: ":chromatic: Deploy Storybook to Chromatic"
-    agents:
-      chromatic: "true"
-    command: nix run .#deploy-to-chromatic
+  - label: ":chromatic: Trigger Chromatic deployment"
+    trigger: primer-app-chromatic
+    async: true
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"


### PR DESCRIPTION
Assuming this works, it will give us a bit more security, as then we
can limit the `chromatic` Buildkite agents to only this repo, and our
other Buildkite agents won't have access to the Chromatic token.