### PR TITLE
fix(ci): Wait for triggered Chromatic deployment build status.

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,7 +12,9 @@ steps:
   - wait
   - label: ":chromatic: Trigger Chromatic deployment"
     trigger: primer-app-chromatic
-    async: true
+    # This can't be async, because we need to be sure the Chromatic
+    # deployment succeeded before merging via Bors.
+    async: false
     build:
       message: "${BUILDKITE_MESSAGE}"
       commit: "${BUILDKITE_COMMIT}"


### PR DESCRIPTION
We can't set `async: true` on the build pipeline, because we need to
be sure the Chromatic deployment succeeded before merging via Bors.