### PR TITLE
fix: Remove devDependencies from dependencies.

### DIFF
--- a/packages/primer-types/package.json
+++ b/packages/primer-types/package.json
@@ -19,25 +19,22 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^5.6.0",
-    "eslint-plugin-import": "^2.25.3",
-    "react": "^17.0.0",
-    "typescript": "^4.5.3",
-    "vite-plugin-optimize-persist": "^0.1.1",
-    "vite-plugin-package-config": "^0.1.0"
+    "react": "^17.0.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
+    "@typescript-eslint/parser": "^5.9.0",
     "eslint": "^8.3.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
-    "typescript": "^4.4.3",
+    "eslint-plugin-import": "^2.25.4",
+    "typescript": "^4.5.4",
     "vite": "^2.5.4",
     "vite-plugin-checker": "^0.3.4",
     "vite-plugin-dts": "^0.9.4",
-    "vite-plugin-optimize-persist": "^0.1.0",
-    "vite-plugin-package-config": "^0.0.3",
+    "vite-plugin-optimize-persist": "^0.1.2",
+    "vite-plugin-package-config": "^0.1.1",
     "vite-tsconfig-paths": "^3.3.17"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,7 +2994,7 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^5.6.0":
+"@typescript-eslint/parser@^5.6.0", "@typescript-eslint/parser@^5.9.0":
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.9.0.tgz#fdbb08767a4caa6ca6ccfed5f9ffe9387f0c7d97"
   integrity sha512-/6pOPz8yAxEt4PLzgbFRDpZmHnXCeZgPDrh/1DaVKOjvn/UPMlWhbx/gA96xRi2JxY1kBl2AmwVbyROUqys5xQ==
@@ -4490,7 +4490,7 @@ color@^4.0.1:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
-colors@1.4.0, colors@^1.1.2:
+colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -6000,7 +6000,7 @@ eslint-plugin-eslint-comments@^3.2.0:
     escape-string-regexp "^1.0.5"
     ignore "^5.0.5"
 
-eslint-plugin-import@^2.25.3:
+eslint-plugin-import@^2.25.3, eslint-plugin-import@^2.25.4:
   version "2.25.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
   integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==
@@ -12208,7 +12208,7 @@ typescript@^2.9.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^4.3.2, typescript@^4.4.3, typescript@^4.5.3:
+typescript@^4.3.2, typescript@^4.4.3, typescript@^4.5.3, typescript@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
   integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
@@ -12746,7 +12746,7 @@ vite-plugin-mdx@^3.5.6:
     resolve "^1.20.0"
     unified "^9.2.1"
 
-vite-plugin-optimize-persist@^0.1.0, vite-plugin-optimize-persist@^0.1.1:
+vite-plugin-optimize-persist@^0.1.0, vite-plugin-optimize-persist@^0.1.1, vite-plugin-optimize-persist@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/vite-plugin-optimize-persist/-/vite-plugin-optimize-persist-0.1.2.tgz#c2aa2712afa74db55f580e3d1656e8cc0b783019"
   integrity sha512-H/Ebn2kZO8PvwUF08SsT5K5xMJNCWKoGX71+e9/ER3yNj7GHiFjNQlvGg5ih/zEx09MZ9m7WCxOwmEKbeIVzww==
@@ -12761,7 +12761,7 @@ vite-plugin-package-config@^0.0.3:
   dependencies:
     debug "^4.3.2"
 
-vite-plugin-package-config@^0.1.0:
+vite-plugin-package-config@^0.1.0, vite-plugin-package-config@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/vite-plugin-package-config/-/vite-plugin-package-config-0.1.1.tgz#6bd579f71db7582ef9dcc05e9f7920e689c498c9"
   integrity sha512-w9B3I8ZnqoyhlbzimXjXNk85imrMZgvI9m8f6j3zonK5IVA5KXzpT+PZOHlDz8lqh1vqvoEI1uhy+ZDoLAiA/w==


### PR DESCRIPTION
I'm not sure how this happened, but in
de6055aed9880a396680378737ceb42d4735110f, several of primer-types'
devDependencies were added to dependencies. This commit fixes that
oversight.