### PR TITLE
ci: Change Dependabot NPM check day to Saturday.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+    day: "saturday"
   reviewers:
     - "dhess"
   commit-message:


### PR DESCRIPTION
By default this runs on Mondays, and it completely clogs up our CI.