### PR TITLE
feat: Add a grouped button list component

### DIFF
--- a/packages/primer-components/src/ActionButton/ActionButton.tsx
+++ b/packages/primer-components/src/ActionButton/ActionButton.tsx
@@ -27,15 +27,33 @@ export interface ActionButtonProps {
   description: string;
 }
 
+const buttonClassesBase =
+  "inline-flex items-center text-base rounded border font-medium shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-offset-2";
+const buttonClassesWidth = "w-full";
+const buttonClassesPrimaryExtra =
+  "border-grey-primary text-blue-primary bg-white-primary hover:bg-blue-primary hover:text-white-primary focus:ring-blue-primary";
+const buttonClassesSecondaryExtra =
+  "border-red-secondary text-white-primary bg-red-secondary hover:bg-red-secondary-hover hover:border-red-secondary-hover focus:ring-red-primary";
+
+// We will want other types of buttons styled roughly the same way
+// We export all the styling combined except the width and padding
+export const buttonClassesPrimary = classNames(
+  buttonClassesBase,
+  buttonClassesPrimaryExtra
+);
+export const buttonClassesSecondary = classNames(
+  buttonClassesBase,
+  buttonClassesSecondaryExtra
+);
+export const buttonClassesPad = "px-1 py-6 pl-7";
+
 const buttonClasses = (appearance: Appearance) =>
   classNames({
-    "border-grey-primary text-blue-primary bg-white-primary hover:bg-blue-primary hover:text-white-primary focus:ring-blue-primary":
-      appearance === "primary",
-
-    "border-red-secondary text-white-primary bg-red-secondary hover:bg-red-secondary-hover hover:border-red-secondary-hover focus:ring-red-primary":
-      appearance === "warning",
-    "inline-flex items-center w-full px-1 py-6 pl-7 text-base rounded border font-medium shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-offset-2":
-      true,
+    [buttonClassesPrimaryExtra]: appearance === "primary",
+    [buttonClassesSecondaryExtra]: appearance === "warning",
+    [buttonClassesBase]: true,
+    [buttonClassesWidth]: true,
+    [buttonClassesPad]: true,
   });
 
 export const ActionButton = (p: ActionButtonProps): JSX.Element => (

--- a/packages/primer-components/src/ActionButton/index.tsx
+++ b/packages/primer-components/src/ActionButton/index.tsx
@@ -1,3 +1,6 @@
-import { ActionButton } from "./ActionButton";
-
-export default ActionButton;
+export {
+  ActionButton as default,
+  buttonClassesPrimary,
+  buttonClassesSecondary,
+  buttonClassesPad,
+} from "./ActionButton";

--- a/packages/primer-components/src/GroupedButtonList/GroupedButtonList.stories.tsx
+++ b/packages/primer-components/src/GroupedButtonList/GroupedButtonList.stories.tsx
@@ -1,0 +1,81 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { GroupedButtonList } from "./GroupedButtonList";
+
+export default {
+  title: "Application/Component Library/GroupedButtonList",
+  component: GroupedButtonList,
+  argTypes: {
+    compact: { control: "boolean", name: "Pack buttons closely?" },
+    expanded: { control: "boolean", name: "Start with dropdowns open?" },
+    groups: { control: "object", name: "List of action groups" },
+  },
+} as ComponentMeta<typeof GroupedButtonList>;
+
+const Template: ComponentStory<typeof GroupedButtonList> = (args) => (
+  <>
+    {/*
+     Let's replace this background color hack with a proper
+     component. See:
+     https://github.com/hackworthltd/primer-app/issues/140
+     */}
+    <div className="p-8 w-1/2 bg-grey-primary">
+      <GroupedButtonList {...args} />
+    </div>
+  </>
+);
+
+export const Examples = Template.bind({});
+Examples.args = {
+  groups: [
+    {
+      heading: "Months, short",
+      actions: [
+        { label: "Jan" },
+        { label: "Feb" },
+        { label: "Mar" },
+        { label: "Apr" },
+        { label: "May" },
+        { label: "Jun" },
+        { label: "Jul" },
+        { label: "Aug" },
+        { label: "Sep" },
+        { label: "Oct" },
+        { label: "Nov" },
+        { label: "Dec" },
+      ],
+    },
+    {
+      heading: "Months, long",
+      actions: [
+        { label: "January" },
+        { label: "Febuary" },
+        { label: "March" },
+        { label: "April" },
+        { label: "May" },
+        { label: "June" },
+        { label: "July" },
+        { label: "August" },
+        { label: "September" },
+        { label: "October" },
+        { label: "November" },
+        { label: "December" },
+      ],
+    },
+    // A mix of different length labels
+    {
+      heading: "Colors",
+      actions: [
+        { label: "Red" },
+        { label: "Blue" },
+        { label: "Magenta" },
+        { label: "Burnt Ochre" },
+        { label: "Rust" },
+        { label: "Pink" },
+        { label: "Eggshell" },
+        { label: "Grey" },
+        { label: "Blanched Almond" },
+      ],
+    },
+  ],
+};

--- a/packages/primer-components/src/GroupedButtonList/GroupedButtonList.tsx
+++ b/packages/primer-components/src/GroupedButtonList/GroupedButtonList.tsx
@@ -1,0 +1,61 @@
+import "@/index.css";
+import { buttonClassesPrimary, buttonClassesPad } from "@/ActionButton";
+
+import classNames from "classnames";
+
+export interface GroupedButtonProps {
+  label: string;
+}
+
+export interface GroupedButtonGroupProps {
+  // NB: headings should be unique, as they are used as react keys
+  heading: string;
+  // NB: labels should be unique as they are used as react keys
+  actions: GroupedButtonProps[];
+}
+
+export interface GroupedButtonListProps {
+  groups: GroupedButtonGroupProps[];
+  expanded: boolean;
+  compact: boolean;
+}
+
+const buttonClasses = buttonClassesPrimary;
+const buttonExtraClassesCompact = "p-6";
+const buttonExtraClassesNonCompact = buttonClassesPad;
+
+export const GroupedButtonList = ({
+  groups,
+  expanded,
+  compact,
+}: GroupedButtonListProps): JSX.Element => (
+  <ul role="list">
+    {groups.map((g) => (
+      <details
+        key={g.heading}
+        className="py-1"
+        open={expanded ? true : undefined}
+      >
+        <summary>{g.heading}</summary>
+        <div
+          className={
+            compact ? "flex flex-row flex-wrap gap-2" : "flex flex-col"
+          }
+        >
+          {g.actions.map((action) => (
+            <button
+              key={action.label}
+              type="button"
+              className={classNames(buttonClasses, {
+                [buttonExtraClassesCompact]: compact,
+                [buttonExtraClassesNonCompact]: !compact,
+              })}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      </details>
+    ))}
+  </ul>
+);

--- a/packages/primer-components/src/GroupedButtonList/index.tsx
+++ b/packages/primer-components/src/GroupedButtonList/index.tsx
@@ -1,0 +1,3 @@
+import { GroupedButtonList } from "./GroupedButtonList";
+
+export default GroupedButtonList;


### PR DESCRIPTION
This will form the basis of a "what do you want to insert" screen, where
we may want to list constructors grouped by what type they are from, or
values grouped by type. We don't implement the "how to group" logic
here (indeed, it is not clear exactly what this logic should be).