### PR TITLE
ci: Remove Intel Mac support from required job set.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -296,10 +296,8 @@
             name = "required";
             constituents = builtins.map builtins.attrValues (with self.hydraJobs; [
               packages.x86_64-linux
-              packages.x86_64-darwin
               packages.aarch64-darwin
               checks.x86_64-linux
-              checks.x86_64-darwin
               checks.aarch64-darwin
             ]);
             meta.description = "Required CI builds";


### PR DESCRIPTION
We still build for Intel Macs, but we don't gate CI on Intel Mac
builds anymore.