### PR TITLE
fix(ci): Tell Mergify not to wait for Chromatic approval for merges.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -34,5 +34,3 @@ queue_rules:
     conditions:
       - base=main
       - check-success="buildkite/primer-app/pr/required"
-      - check-success="UI Review"
-      - check-success="UI Tests"


### PR DESCRIPTION
This fixes (or rather, works around)
https://github.com/hackworthltd/primer-app/issues/313

We do lose some safety here, but this is the expedient fix. See the
issue for details on other approaches we might want to take in the
future, if the approach taken here proves to be problematic.