### PR TITLE
ci: Fix the Mergify config.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,8 +5,8 @@ pull_request_rules:
       - base=main
       - label="Ready to merge"
       - "#changes-requested-reviews-by=0"
-      - check-success="Build the frontend"
-      - check-success="Deploy Storybook.js"
+      - check-success="build-frontend"
+      - check-success="deploy-to-chromatic"
       - check-success="buildkite/primer-app/pr/required-nix-ci"
       - check-success="UI Review"
       - check-success="UI Tests"
@@ -35,4 +35,6 @@ queue_rules:
     allow_inplace_checks: false
     conditions:
       - base=main
-      - check-success="buildkite/primer-app/pr/required"
+      - check-success="buildkite/primer-app/pr/required-nix-ci"
+      - check-success="Build the frontend / build (push)"
+      - check-success="Deploy Storybook.js / build (push)"

--- a/.github/workflows/build-primer-app.yaml
+++ b/.github/workflows/build-primer-app.yaml
@@ -2,13 +2,9 @@ name: Build the frontend
 
 on:
   push:
-    branches:
-      - main
-      - gh-readonly-queue/main/*
-  pull_request:
 
 jobs:
-  build:
+  build-frontend:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -8,7 +8,7 @@ on:
       - dependabot/**
 
 jobs:
-  build:
+  deploy-to-chromatic:
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Fixes https://github.com/hackworthltd/primer-app/issues/363

My previous commit did not properly name the GitHub Action status
checks that Mergify should be waiting for.

On a separate note (for posterity's sake), for each workflow, and for
each job in that workflow, GitHub reports the status check with the
name of that job, and the name is *not* prefixed with the name of the
workflow. Therefore, prior to this commit, both of the workflows in
our CI were reporting a status check with the name `build`, and there
was no way to distinguish them. As of this commit, the jobs have been
renamed `deploy-to-chromatic` and `build-frontend`.

Here I've also configured the "Build the frontend" Action to run on
any push, rather than just `main` and GitHub merge queue branches.
I've also removed the `pull_request` trigger. This is in anticipation
of supporting GitHub merge queues in the future, as the current
implementation of that feature does not create a new PR for merge
queue branches, and therefore the required status check would change
depending on whether we're building a PR or merging a PR into `main`.

This change means that we'll potentially run slightly more CI runs
than if we only run on pull requests. However, as far as I'm aware, we
do not very often do pushes without corresponding pull requests, so in
practice, this effect should be negligible.
