### PR TITLE
fix: Fix Storybook build workflow name, & make Mergify look for it.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,6 +6,7 @@ pull_request_rules:
       - label="Ready to merge"
       - "#changes-requested-reviews-by=0"
       - check-success="build-frontend"
+      - check-success="build-storybook"
       - check-success="buildkite/primer-app/pr/required-nix-ci"
 
       # Currently disabled due to https://github.com/hackworthltd/primer-app/pull/339
@@ -39,5 +40,5 @@ queue_rules:
     conditions:
       - base=main
       - check-success="build-frontend"
-      - check-success="deploy-to-chromatic"
+      - check-success="build-storybook"
       - check-success="buildkite/primer-app/pr/required-nix-ci"

--- a/.github/workflows/build-storybook.yaml
+++ b/.github/workflows/build-storybook.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  build-frontend:
+  build-storybook:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Also, the Mergify `queue_rules` were still gated on the
`deploy-to-chromatic` status check, so I've fixed that here, as well.