### PR TITLE
fix: Get dagre from GitHub.

### DIFF
--- a/packages/primer-components/package.json
+++ b/packages/primer-components/package.json
@@ -32,7 +32,7 @@
     "@visx/shape": "^2.10.0",
     "@visx/text": "^2.10.0",
     "d3": "7.4.4",
-    "dagre": "^0.8.5",
+    "dagre": "github:dagrejs/dagre#103136b04a13c7ac10d8ded25954da58d5ed88e1",
     "fp-ts": "^2.12.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
       chromatic: ^6.5.6
       classnames: ^2.3.1
       d3: 7.4.4
-      dagre: ^0.8.5
+      dagre: github:dagrejs/dagre#103136b04a13c7ac10d8ded25954da58d5ed88e1
       eslint: ^8.17.0
       eslint-config-prettier: ^8.5.0
       eslint-plugin-eslint-comments: ^3.2.0
@@ -182,7 +182,7 @@ importers:
       '@visx/shape': 2.10.0_react@17.0.2
       '@visx/text': 2.10.0_react@17.0.2
       d3: 7.4.4
-      dagre: 0.8.5
+      dagre: github.com/dagrejs/dagre/103136b04a13c7ac10d8ded25954da58d5ed88e1
       fp-ts: 2.12.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -2432,11 +2432,11 @@ packages:
     dependencies:
       '@stoplight/json': 3.17.0
       '@stoplight/path': 1.3.2
-      '@stoplight/types': 12.5.0
+      '@stoplight/types': 12.3.0
       '@types/urijs': 1.19.19
       dependency-graph: 0.11.0
       fast-memoize: 2.5.2
-      immer: 9.0.14
+      immer: 9.0.15
       lodash.get: 4.4.2
       lodash.set: 4.3.2
       tslib: 2.4.0
@@ -2575,7 +2575,7 @@ packages:
     resolution: {integrity: sha512-idvn7r8fvQjY/KeJpKgXQ5eJhce6N6/KoKWMPSh5yyvYDpn+bkU4pxAD79jOJaDnIyKJd1jjTPEJWnxbS0jj6A==}
     engines: {node: '>=12'}
     dependencies:
-      '@stoplight/json': 3.17.0
+      '@stoplight/json': 3.17.2
       '@stoplight/spectral-core': 1.10.1
       '@types/json-schema': 7.0.11
       tslib: 2.4.0
@@ -2661,7 +2661,7 @@ packages:
       '@stoplight/spectral-rulesets': 1.10.0
       '@stoplight/spectral-runtime': 1.1.2
       '@stoplight/types': 12.3.0
-      '@types/node': 17.0.42
+      '@types/node': 18.0.0
       pony-cause: 1.1.1
       rollup: 2.67.3
       tslib: 2.4.0
@@ -2681,7 +2681,7 @@ packages:
       '@stoplight/spectral-runtime': 1.1.2
       '@stoplight/types': 12.3.0
       '@stoplight/yaml': 4.2.2
-      '@types/node': 17.0.42
+      '@types/node': 18.0.0
       ajv: 8.11.0
       ast-types: 0.14.2
       astring: 1.8.3
@@ -4659,7 +4659,7 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.0.0
     dev: true
 
   /@types/lodash/4.14.182:
@@ -4749,7 +4749,7 @@ packages:
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.0.0
     dev: true
 
   /@types/scheduler/0.16.2:
@@ -7408,13 +7408,6 @@ packages:
       d3-timer: 3.0.1
       d3-transition: 3.0.1_d3-selection@3.0.0
       d3-zoom: 3.0.0
-    dev: false
-
-  /dagre/0.8.5:
-    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
-    dependencies:
-      graphlib: 2.1.8
-      lodash: 4.17.21
     dev: false
 
   /data-uri-to-buffer/3.0.1:
@@ -10079,7 +10072,7 @@ packages:
       commander: 2.20.3
       deepmerge: 2.2.1
       find-up: 3.0.0
-      globby: 11.0.4
+      globby: 11.1.0
       js-yaml: 3.14.1
       json-dup-key-validator: 1.0.3
       json-schema-ref-parser: 5.1.3
@@ -10136,8 +10129,8 @@ packages:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
     engines: {node: '>= 4'}
 
-  /immer/9.0.14:
-    resolution: {integrity: sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==}
+  /immer/9.0.15:
+    resolution: {integrity: sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==}
     dev: true
 
   /import-fresh/3.3.0:
@@ -12318,7 +12311,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       got: 9.6.0
-      registry-auth-token: 4.2.1
+      registry-auth-token: 4.2.2
       registry-url: 5.1.0
       semver: 6.3.0
     dev: true
@@ -13423,8 +13416,8 @@ packages:
       unicode-match-property-value-ecmascript: 2.0.0
     dev: true
 
-  /registry-auth-token/4.2.1:
-    resolution: {integrity: sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==}
+  /registry-auth-token/4.2.2:
+    resolution: {integrity: sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==}
     engines: {node: '>=6.0.0'}
     dependencies:
       rc: 1.2.8
@@ -15628,7 +15621,7 @@ packages:
   /vscode-css-languageservice/3.0.13:
     resolution: {integrity: sha512-RWkO/c/A7iXhHEy3OuEqkCqavDjpD4NF2Ca8vjai+ZtEYNeHrm1ybTnBYLP4Ft1uXvvaaVtYA9HrDjD6+CUONg==}
     dependencies:
-      vscode-languageserver-types: 3.17.1
+      vscode-languageserver-types: 3.16.0
       vscode-nls: 4.1.2
     dev: true
 
@@ -15641,7 +15634,7 @@ packages:
       vscode-html-languageservice: 2.1.12
       vscode-languageserver: 4.4.2
       vscode-languageserver-protocol-foldingprovider: 2.0.1
-      vscode-languageserver-types: 3.17.1
+      vscode-languageserver-types: 3.16.0
       vscode-nls: 3.2.5
       vscode-uri: 1.0.8
     dev: true
@@ -15649,7 +15642,7 @@ packages:
   /vscode-html-languageservice/2.1.12:
     resolution: {integrity: sha512-mIb5VMXM5jI97HzCk2eadI1K//rCEZXte0wBqA7PGXsyJH4KTyJUaYk9MR+mbfpUl2vMi3HZw9GUOLGYLc6l5w==}
     dependencies:
-      vscode-languageserver-types: 3.17.1
+      vscode-languageserver-types: 3.16.0
       vscode-nls: 4.1.2
       vscode-uri: 1.0.8
     dev: true
@@ -15673,7 +15666,7 @@ packages:
     dependencies:
       jsonc-parser: 3.0.0
       vscode-languageserver-textdocument: 1.0.5
-      vscode-languageserver-types: 3.17.1
+      vscode-languageserver-types: 3.16.0
       vscode-nls: 5.0.1
       vscode-uri: 3.0.3
     dev: true
@@ -15683,7 +15676,7 @@ packages:
     dependencies:
       jsonc-parser: 3.0.0
       vscode-languageserver-textdocument: 1.0.5
-      vscode-languageserver-types: 3.17.1
+      vscode-languageserver-types: 3.16.0
       vscode-nls: 5.0.1
       vscode-uri: 3.0.3
     dev: true
@@ -15695,11 +15688,6 @@ packages:
   /vscode-jsonrpc/6.0.0:
     resolution: {integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==}
     engines: {node: '>=8.0.0 || >=10.0.0'}
-
-  /vscode-jsonrpc/8.0.1:
-    resolution: {integrity: sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==}
-    engines: {node: '>=14.0.0'}
-    dev: true
 
   /vscode-languageclient/7.0.0:
     resolution: {integrity: sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==}
@@ -15713,8 +15701,8 @@ packages:
   /vscode-languageserver-protocol-foldingprovider/2.0.1:
     resolution: {integrity: sha512-N8bOS8i0xuQMn/y0bijyefDbOsMl6hiH6LDREYWavTLTM5jbj44EiQfStsbmAv/0eaFKkL/jf5hW7nWwBy2HBw==}
     dependencies:
-      vscode-languageserver-protocol: 3.17.1
-      vscode-languageserver-types: 3.17.1
+      vscode-languageserver-protocol: 3.16.0
+      vscode-languageserver-types: 3.16.0
     dev: true
 
   /vscode-languageserver-protocol/3.16.0:
@@ -15723,28 +15711,17 @@ packages:
       vscode-jsonrpc: 6.0.0
       vscode-languageserver-types: 3.16.0
 
-  /vscode-languageserver-protocol/3.17.1:
-    resolution: {integrity: sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==}
-    dependencies:
-      vscode-jsonrpc: 8.0.1
-      vscode-languageserver-types: 3.17.1
-    dev: true
-
   /vscode-languageserver-textdocument/1.0.5:
     resolution: {integrity: sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg==}
 
   /vscode-languageserver-types/3.16.0:
     resolution: {integrity: sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==}
 
-  /vscode-languageserver-types/3.17.1:
-    resolution: {integrity: sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==}
-    dev: true
-
   /vscode-languageserver/4.4.2:
     resolution: {integrity: sha512-61y8Raevi9EigDgg9NelvT9cUAohiEbUl1LOwQQgOCAaNX62yKny/ddi0uC+FUTm4CzsjhBu+06R+vYgfCYReA==}
     hasBin: true
     dependencies:
-      vscode-languageserver-protocol: 3.17.1
+      vscode-languageserver-protocol: 3.16.0
       vscode-uri: 1.0.8
     dev: true
 
@@ -15810,7 +15787,7 @@ packages:
     dev: true
 
   /wcwidth/1.0.1:
-    resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
       defaults: 1.0.3
     dev: true
@@ -15820,7 +15797,7 @@ packages:
     dev: true
 
   /webidl-conversions/3.0.1:
-    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: true
 
   /webpack-dev-middleware/3.7.3_webpack@4.46.0:
@@ -15964,7 +15941,7 @@ packages:
     dev: true
 
   /whatwg-url/5.0.0:
-    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
@@ -16127,7 +16104,7 @@ packages:
       vscode-json-languageservice: 4.1.8
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.5
-      vscode-languageserver-types: 3.17.1
+      vscode-languageserver-types: 3.16.0
       vscode-nls: 5.0.1
       vscode-uri: 3.0.3
       yaml: 2.0.0-11
@@ -16231,3 +16208,12 @@ packages:
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
+
+  github.com/dagrejs/dagre/103136b04a13c7ac10d8ded25954da58d5ed88e1:
+    resolution: {tarball: https://codeload.github.com/dagrejs/dagre/tar.gz/103136b04a13c7ac10d8ded25954da58d5ed88e1}
+    name: dagre
+    version: 0.8.6-pre
+    dependencies:
+      graphlib: 2.1.8
+      lodash: 4.17.21
+    dev: false


### PR DESCRIPTION
The previous release, 0.8.5, is 3 years old, and there have been some
changes since that, to date, are only available via the project's
GitHub repo.

Via:

```
cd packages/primer-components
pnpm remove dagre
pnpm add github:dagrejs/dagre#103136b04a13c7ac10d8ded25954da58d5ed88e1
cd ../..
pnpm install
```