### PR TITLE
ci: Run `pnpm audit --prod` in CI.

### DIFF
--- a/.github/workflows/build-primer-app.yaml
+++ b/.github/workflows/build-primer-app.yaml
@@ -32,3 +32,9 @@ jobs:
       # be able to resolve some paths.
       - name: Lint
         run: pnpm lint
+
+      # Note: we only audit non-dev dependencies, because there are
+      # nearly always dev dependency vulnerabilities, but they're very
+      # unlikely to affect the production app.
+      - name: Audit
+        run: pnpm audit --prod


### PR DESCRIPTION
Note: we only audit non-dev dependencies, because there are nearly
always dev dependency vulnerabilities, but they're very unlikely to
affect the production app.