### PR TITLE
Don't use all-capitals in T&D bar headings

### DIFF
--- a/packages/primer-components/src/Sidebar/Sidebar.tsx
+++ b/packages/primer-components/src/Sidebar/Sidebar.tsx
@@ -131,7 +131,9 @@ const DefList = (
   return (
     <div>
       <div className="flex gap-2">
-        <div className={classNames("text-blue-primary", headerStyle)}>
+        <div
+          className={classNames("text-blue-primary text-lg mb-1", headerStyle)}
+        >
           {heading}
         </div>
         {expanded ? (


### PR DESCRIPTION
This came up in passing in a conversation between @dhess and I yesterday, where we decided we both prefer this, contrary to our Figma designs.