### PR TITLE
chore: Install Node.js 16 in GitHub workflows.

### DIFF
--- a/.github/workflows/build-primer-app.yaml
+++ b/.github/workflows/build-primer-app.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14
+          node-version: 16
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14
+          node-version: 16
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
This matches what Nix installs for local builds.
