### PR TITLE
chore!: Upgrade to Node.js 18 and remove `pnpm` from Nix shell.

### DIFF
--- a/.github/workflows/build-primer-app.yaml
+++ b/.github/workflows/build-primer-app.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14
+          node-version: 18
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14
+          node-version: 18
           cache: "pnpm"
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Note that, in this project, we do *not* use Nix in any significant capacity. Nix
 
 ## Interactive development
 
-To develop interactively, enter the Nix shell via `nix develop`. Once there, you can run all the usual `pnpm` commands.
+To develop interactively, enter the Nix shell via `nix develop`. Note that due to https://github.com/NixOS/nixpkgs/issues/132456, we cannot use Nix to install `pnpm` with any version of Node.js > 14, so the first time you check out the `primer-app` repo, you'll need to run `npx pnpm install` to bootstrap a new repo. 
 
-In particular, as a first time setup you will need to run `pnpm install` to populate the `node_modules` directories before other commands will work. Once the local packages are installed, you can run commands such as `pnpm build` and `pnpm watch`.
+After the initial bootstrap, you'll be able to run just `nix develop` and then all the standard `pnpm` command should work.
 
 ### The top-level package
 

--- a/flake.nix
+++ b/flake.nix
@@ -157,10 +157,9 @@
           buildInputs = (with pkgs; [
             actionlint
             flyctl
-            nodejs
             nixpkgs-fmt
+            nodejs-18_x
             rnix-lsp
-            nodePackages.pnpm
           ]);
 
           # Make sure the Nix shell includes node_modules's bin dir in

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "@hackworthltd/primer",
   "private": true,
   "engines": {
-    "node": "^14.19.2",
+    "node": "^18.6.0",
     "pnpm": "^7.1.0"
   },
   "devDependencies": {
+    "pnpm": "^7.6.0",
     "@typescript-eslint/parser": "^5.30.6",
     "eslint": "^8.20.0",
     "eslint-import-resolver-typescript": "^3.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ importers:
       eslint: ^8.20.0
       eslint-import-resolver-typescript: ^3.2.6
       eslint-plugin-import: ^2.26.0
+      pnpm: ^7.6.0
       prettier: ^2.7.1
       typescript: ^4.7.4
       typescript-eslint-language-service: ^5.0.0
@@ -28,6 +29,7 @@ importers:
       eslint: 8.20.0
       eslint-import-resolver-typescript: 3.3.0_afl3vkhn63baibzal45igheroq
       eslint-plugin-import: 2.26.0_ng73mesgr3qjuo2tra2ynrmv5i
+      pnpm: 7.6.0
       prettier: 2.7.1
       typescript: 4.7.4
       typescript-eslint-language-service: 5.0.0_6wltbjakwuqm7awqswigmiuhd4
@@ -11976,6 +11978,12 @@ packages:
       ts-pnp: 1.2.0_typescript@4.7.4
     transitivePeerDependencies:
       - typescript
+    dev: true
+
+  /pnpm/7.6.0:
+    resolution: {integrity: sha512-pCFZ4OSM3M7JUHShnmk4Hlt9A8QDxLx+i+9kkK4g60YuYhhhD3oqBfWrHax0/XMDvr7GwK0fqFjA8iD8HlZ8Kw==}
+    engines: {node: '>=14.6'}
+    hasBin: true
     dev: true
 
   /polished/4.2.2:


### PR DESCRIPTION
BREAKING CHANGE: you must now bootstrap your `primer-app` repo via
`npx pnpm install`.

Prior to this change, we used `nodePackages.pnpm` in our Nix shell so
that we didn't need to bootstrap-install `pnpm` from `packages.json`.
Due to https://github.com/NixOS/nixpkgs/issues/132456, `nodePackages`
is stuck on Node.js v14, so one consequence of this approach is that
we were effectively also stuck on Node.js v14, since everything in
this repo goes through `pnpm`.

Unfortunately, many tools now require Node.js > v14, as v14 is now
deprecated and v16 is the LTS version. Chief amongst these tools that
require later versions of Node.js is the GitHub action for Cloudflare
Pages deployments, which we want to use to deploy frontend assets.

This change installs `nodejs-18_x` from nixpkgs into the Nix shell,
but no longer installs `nodePackages.pnpm`. We now add `pnpm` to the
local `packages.json` file and bootstrap a new repo via `npx pnpm
install`, which will install `pnpm` in `node_modules/.bin/`. Then, via
our Nix shell `shellHook`, we can add that subdirectory to `$PATH` and
get `pnpm` via Node.js, rather than via Nix. Note that this bootstrap
step only needs to be performed the first time one checks out the
`primer-app` repo.
