### PR TITLE
feat: Simpler and hopefully faster CI.

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,9 +1,4 @@
-env:
-  CACHIX_CONFIG: /var/lib/cachix/hackworthltd-private/cachix.dhall
-  CACHIX_CACHE: hackworthltd-private
-
 agents:
-  private: "true"
   os: "linux"
 
 steps:
@@ -12,33 +7,17 @@ steps:
     plugins:
       - circuithub/nix-buildkite:
           file: ci.nix
-          post-build-hook:
-            /run/current-system/sw/bin/buildkite-private-post-build-hook
+
   - label: ":nixos: Archive Nix flake inputs"
-    command: nix flake archive --json | jq -r '.path,(.inputs|to_entries[].value.path)' | cachix --verbose --config "$CACHIX_CONFIG" push "$CACHIX_CACHE"
+    command: nix flake archive .#
+
   - wait
+
   - label: ":nixos: :linux: Cache the Nix shell"
     command: |
-      nix develop --print-build-logs --profile /tmp/primer-app --command cachix --verbose --config "$CACHIX_CONFIG" push "$CACHIX_CACHE" /tmp/primer-app
+      nix develop --print-build-logs --profile /tmp/primer-app --command echo "done"
   - label: ":nixos: :macos: Cache the Nix shell"
     command: |
-      nix develop --print-build-logs --profile /tmp/primer-app --command cachix --verbose --config "$CACHIX_CONFIG" push "$CACHIX_CACHE" /tmp/primer-app
+      nix develop --print-build-logs --profile /tmp/primer-app --command echo "done"
     agents:
       os: "darwin"
-
-  # Currently disabled due to:
-  # https://github.com/hackworthltd/primer-app/pull/339
-
-  # - label: ":chromatic: Trigger Chromatic deployment"
-  #   trigger: primer-app-chromatic
-  #   # This can't be async, because we need to be sure the Chromatic
-  #   # deployment succeeded before merging via Bors.
-  #   async: false
-  #   build:
-  #     message: "${BUILDKITE_MESSAGE}"
-  #     commit: "${BUILDKITE_COMMIT}"
-  #     branch: "${BUILDKITE_BRANCH}"
-  #     env:
-  #       BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
-  #       BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-  #       BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"


### PR DESCRIPTION
I believe now that our CI builders push everything that's written to
their local store to our Cachix private cache, we no longer need a
post-build hook for the nix-buildkite plugin, nor do we need to
explicitly push the `nix develop` profiles to Cachix -- we can simply
build whatever product we want and the Cachix watch-store process will
take care of everything. (I think.)
