### PR TITLE
chore(primer): Bump primer pin.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -953,17 +953,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1660039850,
-        "narHash": "sha256-vxhohWwmL3CBS7GHy0qlgNGXO9Kx2xUFcEhxOaVzckQ=",
+        "lastModified": 1660566137,
+        "narHash": "sha256-FKt1MDsFtSwmIrzv038JvcDj4Lu0VTMbrVwAufYdB6I=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "08bed16526a18541870ae4165b32128fba946ec8",
+        "rev": "df9fa310a134acd4a637870cd791c038bb5843f4",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "08bed16526a18541870ae4165b32128fba946ec8",
+        "rev": "df9fa310a134acd4a637870cd791c038bb5843f4",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/08bed16526a18541870ae4165b32128fba946ec8;
+    primer.url = github:hackworthltd/primer/df9fa310a134acd4a637870cd791c038bb5843f4;
   };
 
   outputs =


### PR DESCRIPTION
Note: no OpenAPI changes in this bump. However, this version supports deploying example apps via the Servant API, so with this change, we'll be able to automatically populate new databases with examples.