### PR TITLE
chore(nix): Bump Primer pin.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,17 +1007,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1662376776,
-        "narHash": "sha256-NoC2Kl1/ue8oREf2KD8NeZsi2K1dvmr4ifC7Yub+NZ8=",
+        "lastModified": 1662383499,
+        "narHash": "sha256-tjfl0eRyPidFIQiuKpkADZraXqlmCRlBKQ2B6wIUr20=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "9dae1af917e39a26627e2bd69b466c902519fc31",
+        "rev": "8830515452a6717bc90c6f69d7629be17766288b",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "9dae1af917e39a26627e2bd69b466c902519fc31",
+        "rev": "8830515452a6717bc90c6f69d7629be17766288b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/9dae1af917e39a26627e2bd69b466c902519fc31;
+    primer.url = github:hackworthltd/primer/8830515452a6717bc90c6f69d7629be17766288b;
   };
 
   outputs =


### PR DESCRIPTION
This pin includes code which will hopefully resolve our Fly.io
database timeout issues.
