### PR TITLE
chore(nix): Bump Primer pin.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1007,17 +1007,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1662383499,
-        "narHash": "sha256-tjfl0eRyPidFIQiuKpkADZraXqlmCRlBKQ2B6wIUr20=",
+        "lastModified": 1662390168,
+        "narHash": "sha256-gEXyY1Kjo+7R7X4g43hkM2J/gn9E7r92Bo9k2fwPN/A=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "8830515452a6717bc90c6f69d7629be17766288b",
+        "rev": "97001bb7ba27bd9374ff0db1005015322a26be7a",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "8830515452a6717bc90c6f69d7629be17766288b",
+        "rev": "97001bb7ba27bd9374ff0db1005015322a26be7a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/8830515452a6717bc90c6f69d7629be17766288b;
+    primer.url = github:hackworthltd/primer/97001bb7ba27bd9374ff0db1005015322a26be7a;
   };
 
   outputs =


### PR DESCRIPTION
This upstream lowers the database connection timeout from 10s to 1s.
