### PR TITLE
ci: Turn `eslint` warnings into errors.

### DIFF
--- a/.github/workflows/build-primer-app.yaml
+++ b/.github/workflows/build-primer-app.yaml
@@ -31,7 +31,7 @@ jobs:
       # Note: linting must come after building, or else eslint won't
       # be able to resolve some paths.
       - name: Lint
-        run: pnpm lint
+        run: pnpm lint --max-warnings=0
 
       # Note: we only audit non-dev dependencies, because there are
       # nearly always dev dependency vulnerabilities, but they're very

--- a/packages/primer-app/src/main.tsx
+++ b/packages/primer-app/src/main.tsx
@@ -10,7 +10,13 @@ import App from "./App";
 
 const queryClient = new QueryClient();
 const rootElement: HTMLElement | null = document.getElementById("root");
-const root = createRoot(rootElement!);
+if (!rootElement) {
+  throw new Error(
+    "The HTML root element doesn't exist. Please report this error!"
+  );
+}
+
+const root = createRoot(rootElement);
 
 root.render(
   <React.StrictMode>

--- a/packages/primer-app/vite.config.ts
+++ b/packages/primer-app/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
-import checker from "vite-plugin-checker";
+import { checker } from "vite-plugin-checker";
 import PkgConfig from "vite-plugin-package-config";
 import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/packages/primer-components/vite.config.ts
+++ b/packages/primer-components/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
-import checker from "vite-plugin-checker";
+import { checker } from "vite-plugin-checker";
 import dts from "vite-plugin-dts";
 import path from "path";
 import tsconfigPaths from "vite-tsconfig-paths";

--- a/packages/primer-types/vite.config.ts
+++ b/packages/primer-types/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import checker from "vite-plugin-checker";
+import { checker } from "vite-plugin-checker";
 import dts from "vite-plugin-dts";
 import path from "path";
 import tsconfigPaths from "vite-tsconfig-paths";


### PR DESCRIPTION
Upstream doesn't seem particularly interested in supporting this mode, but there's a workaround, which we implement in this commit:

https://github.com/eslint/eslint/issues/2309#issuecomment-219828044

This commit also fixes the remaining warnings in the current code base.