### PR TITLE
chore: Bump the Primer pin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ The main reason for this project organization is so that Hackworth members and o
 
 Because the Primer backend project is open source, and this project is not, the 2 projects must live in separate repositories. In order to keep the frontend code in sync with a particular version of the Primer backend/API, we pin the Primer backend repo to a particular git commit/rev via a Nix flake input pin. This ensures that when we run a local `primer-service` instance during development ([see below](#Running-a-local-`primer-service`-instance)), we're running the correct version of the backend for the current frontend, and we don't need to worry about keeping our local copies of these 2 repos in sync. The drawback to this approach is that if we need to make backend changes to accommodate a new frontend feature, we must first commit those changes to the backend repo's `main` branch before we can update the local Nix flake pin. (However, we can always fall back to running the local `primer-service` from a local copy of the backend repo, if necessary.)
 
+To bump the Primer pin, update the Primer git rev in `nix.flake`, and then run the following commands:
+
+```sh
+nix flake update
+nix develop
+```
+
+(The `nix develop` step ensures that this project's API bindings are up to date with Primer's.)
+
 ## Build system
 
 All of the packages in this monorepo are built with the [Vite build system](https://vitejs.dev/guide/). While this build system isn't as full-featured as [Create React App](https://create-react-app.dev), it's much simpler, more agile, and significantly faster than [Webpack](https://webpack.js.org), which underpins Create React App and is a major contributor to Create React App's complexity.

--- a/flake.lock
+++ b/flake.lock
@@ -147,6 +147,23 @@
         "type": "github"
       }
     },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632802058,
+        "narHash": "sha256-7IySNHriQjzOZ88DDk6VDPf1GoUaOrOeUdukY62o52o=",
+        "owner": "hamishmack",
+        "repo": "flake-compat",
+        "rev": "5523c47f13259b981c49b26e28499724a5125fd8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/pkgs-fetch",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1659877975,
@@ -294,11 +311,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1662167627,
-        "narHash": "sha256-Wwq4oVlvBXkZbhABSdakt0KyRh5VOULvNFXoYR9+88g=",
+        "lastModified": 1662772451,
+        "narHash": "sha256-ilkCYrbktOl1kvMJ/zRZaoS41AVabHgaeUNfpwvDgW4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "be51362f6e0dda9007d140d82ad57d314a08491f",
+        "rev": "18aa3d7550a3eee83a0aee1246406c9add46fd2e",
         "type": "github"
       },
       "original": {
@@ -344,11 +361,11 @@
         "sops-nix": "sops-nix_2"
       },
       "locked": {
-        "lastModified": 1662163817,
-        "narHash": "sha256-sThvHVnXWRGpblVWSn7KBntFIQfx1wiorpmw8Efdi+U=",
+        "lastModified": 1662770742,
+        "narHash": "sha256-xaOE/a37n1nHRMMmE0UFneXTQ04ahxVUBZKD5lrkOl8=",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "b88adfe09e95c9b9f1eddd791df02de54bcdf9e7",
+        "rev": "db9c74ecfbb0518508e2701ae35e0ce61be712bb",
         "type": "github"
       },
       "original": {
@@ -360,11 +377,11 @@
     "haskell-language-server": {
       "flake": false,
       "locked": {
-        "lastModified": 1662139321,
-        "narHash": "sha256-2/cq+jIZrtpyPQH1RZzzVDI1vKPR9zu6HqwnDdkhK+w=",
+        "lastModified": 1662666864,
+        "narHash": "sha256-1fECkXiIt04RIFBu7hCDrGUOUgNVVn3rEzi/D7UbawI=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "5b229b631fbc3b53fdacd1092aacb55f8f2de4a3",
+        "rev": "3fb4082f8038d573d7636a2d74aa1be70d317cc2",
         "type": "github"
       },
       "original": {
@@ -380,6 +397,7 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat_5",
         "flake-utils": "flake-utils_5",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
@@ -400,11 +418,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1662168467,
-        "narHash": "sha256-GNRTZWMICMxy1Xf5BQjyTnpQLBvLz5x0h+BukgzFqoU=",
+        "lastModified": 1662786284,
+        "narHash": "sha256-4ArqOMoul3PXeIO0BPfARBlJJ4dSYnRZl//cKzVcEww=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "b3df33abbcb736437cb06d5f53a10f6bb271bc51",
+        "rev": "20c33afad920746af56329f7a92423c244bfabbe",
         "type": "github"
       },
       "original": {
@@ -506,17 +524,17 @@
     "lsp": {
       "flake": false,
       "locked": {
-        "lastModified": 1661124122,
-        "narHash": "sha256-SBQI5Wl0s/SGJk4avV+B8X4eqk+QEAqkHWYhyRVibvg=",
+        "lastModified": 1662291729,
+        "narHash": "sha256-KlL38v/75G9zrW7+IiUeiCxFfLJGm/EdFeWQRUikab8=",
         "owner": "haskell",
         "repo": "lsp",
-        "rev": "c95eb06c70c35f1e13c37ed11a7d9e5b36bfa2e8",
+        "rev": "b0f8596887088b8ab65fc1015c773f45b47234ae",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
         "repo": "lsp",
-        "rev": "c95eb06c70c35f1e13c37ed11a7d9e5b36bfa2e8",
+        "rev": "b0f8596887088b8ab65fc1015c773f45b47234ae",
         "type": "github"
       }
     },
@@ -565,16 +583,16 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1654208062,
-        "narHash": "sha256-17js57bOkrOXuQ5pokrvw4od7dsgjjL64f59b1UoHrA=",
+        "lastModified": 1662213991,
+        "narHash": "sha256-oTz2xnMIdVWY7Izgw48zv5iznSXNblTp376MN24oW4s=",
         "owner": "hackworthltd",
         "repo": "nix-darwin",
-        "rev": "6e6e732093a2f9b9568feef11f8eb040f458650f",
+        "rev": "335e7ba231e5132f824dd31ee9d4f80c5599a4b1",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
-        "ref": "fixes-v17",
+        "ref": "fixes-v18",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -766,11 +784,11 @@
     },
     "nixpkgs-22_05_2": {
       "locked": {
-        "lastModified": 1661656705,
-        "narHash": "sha256-1ujNuL1Tx1dt8dC/kuYS329ZZgiXXmD96axwrqsUY7w=",
+        "lastModified": 1662221733,
+        "narHash": "sha256-dw1xjYyQ0JidXIpzeQh/gQX+ih1sJO1zBHKs5QSYp8Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "290dbaacc1f0b783fd8e271b585ec2c8c3b03954",
+        "rev": "013e8d86d9a3f33074c903c8ffcab0d34087b1ed",
         "type": "github"
       },
       "original": {
@@ -843,11 +861,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1661799568,
-        "narHash": "sha256-P3xXCyYfd6WzVC3anpb5ZvUeZ6vMttcs05OWGWvgc+E=",
+        "lastModified": 1662096612,
+        "narHash": "sha256-R+Q8l5JuyJryRPdiIaYpO5O3A55rT+/pItBrKcy7LM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3e4dc4f6d23c7e41dda5ce98956c75c7779e2fa",
+        "rev": "21de2b973f9fee595a7a1ac4693efff791245c34",
         "type": "github"
       },
       "original": {
@@ -924,11 +942,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660830093,
-        "narHash": "sha256-HUhx3a82C7bgp2REdGFeHJdhEAzMGCk3V8xIvfBqg1I=",
+        "lastModified": 1663082609,
+        "narHash": "sha256-lmCCIu4dj59qbzkGKHQtolhpIEQMeAd2XUbXVPqgPYo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8cb8ea5f1c7bc2984f460587fddd5f2e558f6eb8",
+        "rev": "60cad1a326df17a8c6cf2bb23436609fdd83024e",
         "type": "github"
       },
       "original": {
@@ -1007,17 +1025,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1662390168,
-        "narHash": "sha256-gEXyY1Kjo+7R7X4g43hkM2J/gn9E7r92Bo9k2fwPN/A=",
+        "lastModified": 1663097702,
+        "narHash": "sha256-D+u8XKfb3y7LPLL4a2BzTVnpqD2x4WinmzML808HXyw=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "97001bb7ba27bd9374ff0db1005015322a26be7a",
+        "rev": "99bca5991900876f20c0ddc933c35a75ef546ab5",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "97001bb7ba27bd9374ff0db1005015322a26be7a",
+        "rev": "99bca5991900876f20c0ddc933c35a75ef546ab5",
         "type": "github"
       }
     },
@@ -1067,11 +1085,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05_2"
       },
       "locked": {
-        "lastModified": 1661660105,
-        "narHash": "sha256-3ITdkYwsNDh2DRqi7FZOJ92ui92NmcO6Nhj49u+JjWY=",
+        "lastModified": 1662390490,
+        "narHash": "sha256-HnFHRFu0eoB0tLOZRjLgVfHzK+4bQzAmAmHSzOquuyI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d92fba1bfc9f64e4ccb533701ddd8590c0d8c74a",
+        "rev": "044ccfe24b349859cd9efc943e4465cc993ac84e",
         "type": "github"
       },
       "original": {
@@ -1083,11 +1101,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1662168405,
-        "narHash": "sha256-qjtrcff65O7gczkGtkdm8NByCn9GvI1EpVo1YvEJz7s=",
+        "lastModified": 1662772551,
+        "narHash": "sha256-nv6u7nG2ep+BTGaOluEv/UY+Q8byCGPEHit5PvVI85U=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "20b2b927e744310916eea9d0dbc08255a5f431c4",
+        "rev": "f723a28a9dc39f10782338e0431fc2be578c3f3c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/97001bb7ba27bd9374ff0db1005015322a26be7a;
+    primer.url = github:hackworthltd/primer/99bca5991900876f20c0ddc933c35a75ef546ab5;
   };
 
   outputs =

--- a/packages/primer-app/src/primer-api/model/nodeFlavor.ts
+++ b/packages/primer-app/src/primer-api/model/nodeFlavor.ts
@@ -33,6 +33,7 @@ export const NodeFlavor = {
   FlavorTVar: "FlavorTVar",
   FlavorTApp: "FlavorTApp",
   FlavorTForall: "FlavorTForall",
+  FlavorTLet: "FlavorTLet",
   FlavorPattern: "FlavorPattern",
   FlavorPatternCon: "FlavorPatternCon",
   FlavorPatternBind: "FlavorPatternBind",

--- a/packages/primer-components/src/TreeReactFlow/TreeReactFlow.tsx
+++ b/packages/primer-components/src/TreeReactFlow/TreeReactFlow.tsx
@@ -69,6 +69,8 @@ function flavorColor(flavor: NodeFlavor): string {
       return "black";
     case "FlavorTForall":
       return "black";
+    case "FlavorTLet":
+      return "black";
     case "FlavorPattern":
       return "#ffb961";
     case "FlavorPatternCon":
@@ -128,6 +130,8 @@ function flavorLabel(flavor: NodeFlavor): string {
       return "@";
     case "FlavorTForall":
       return "∀";
+    case "FlavorTLet":
+      return "let";
     case "FlavorPattern":
       return "P";
     case "FlavorPatternCon":

--- a/packages/primer-types/src/Tree.ts
+++ b/packages/primer-types/src/Tree.ts
@@ -94,6 +94,7 @@ export const NodeFlavor = {
   FlavorTVar: "FlavorTVar",
   FlavorTApp: "FlavorTApp",
   FlavorTForall: "FlavorTForall",
+  FlavorTLet: "FlavorTLet",
   FlavorPattern: "FlavorPattern",
   FlavorPatternCon: "FlavorPatternCon",
   FlavorPatternBind: "FlavorPatternBind",


### PR DESCRIPTION
Also, add a note to the README about the steps needed to update the pin.

Note that this version of Primer includes our initial logging support.