### PR TITLE
ReactFlow visual improvements

### DIFF
--- a/packages/primer-components/src/TreeReactFlow/TreeReactFlow.tsx
+++ b/packages/primer-components/src/TreeReactFlow/TreeReactFlow.tsx
@@ -175,7 +175,7 @@ const PrimerNode = (p: NodeProps<PrimerNodeProps>) => {
       <Handle type="target" position={Position.Top} className={handleStyle} />
       <div
         className={classNames(
-          "flex items-center justify-center rounded border-4 text-grey-tertiary",
+          "flex items-center justify-center rounded border-4 text-grey-tertiary bg-white-primary",
           p.data.selected && "outline outline-4 outline-offset-4"
         )}
         style={{
@@ -242,6 +242,8 @@ const convertTree = (
       target,
       style: { stroke: flavorColor(tree.flavor) },
       className: "stroke-[0.25rem]",
+      // We draw edges above nodes, so that they aren't hidden by nodes' solid backgrounds.
+      zIndex: 1,
     };
   });
   const childNodes = children.flatMap(({ nodes }) => nodes);


### PR DESCRIPTION
This contains some changes which we've informally discussed (e.g. on Keybase), and which I experimented with during https://github.com/hackworthltd/primer-app/pull/518, but which aren't explicitly related to that PR.

I personally think they are a big improvement, and that this is clear now that we can see the canvas and panels together.

Bear in mind that I will soon be re-investigating alternative libraries for tree layout and rendering (with Cytoscape the current frontrunner), so it's not worth chasing perfection on the visuals yet. These are just some easy wins.