### PR TITLE
chore: Disable Vite error/warning overlay

### DIFF
--- a/packages/primer-app/vite.config.ts
+++ b/packages/primer-app/vite.config.ts
@@ -12,6 +12,7 @@ export default ({ mode }) => {
     plugins: [
       checker({
         typescript: true,
+        overlay: false,
       }),
       react(),
       tsconfigPaths(),


### PR DESCRIPTION
Seeing as warnings and errors are also visible via the output of `pnpm build`/`pnpm watch` and through editor plugins, this is likely to be redundant anyway for most developers.

The overlay can be closed, but if the number of errors+warnings goes down to zero then back up, it reappears. This is particularly annoying when using `pnpm watch` to monitor visual output without otherwise interacting with the app. Especially when there are only warnings of little consequence, such as unused variables.