### PR TITLE
fix: Remove redundant `toString` calls for tree IDs

### DIFF
--- a/packages/primer-components/src/TreeReactFlow/TreeReactFlow.tsx
+++ b/packages/primer-components/src/TreeReactFlow/TreeReactFlow.tsx
@@ -219,7 +219,7 @@ const convertTree = (
     tree.rightChild ? [tree.rightChild] : []
   );
   const children = childTrees.map((t) => convertTree(t, def, nodeType, p));
-  const id = tree.nodeId.toString();
+  const id = tree.nodeId;
   const thisNode = (
     data: Omit<PrimerNodePropsNode, "selected">
   ): NodeNoPos<PrimerNodeProps> => {
@@ -235,7 +235,7 @@ const convertTree = (
     };
   };
   const thisToChildren: Edge<never>[] = childTrees.map((t) => {
-    const target = t.nodeId.toString();
+    const target = t.nodeId;
     return {
       id: JSON.stringify([id, target]),
       source: id,


### PR DESCRIPTION
Note that in JS, `s.toString` equals `s`, unlike e.g. `show @String` in Haskell. So this makes no actual difference to anything. It just removes a tiny bit of cruft.