### PR TITLE
chore(nix): Bump Primer pin.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664708386,
-        "narHash": "sha256-aCD8UUGNYb5nYzRmtsq/0yP9gFOQQHr/Lsb5vW+mucw=",
+        "lastModified": 1665395272,
+        "narHash": "sha256-kkV5gfDJWMxKmYq3Y2pgvD7zH/I3WoW/0wr659Stj1Q=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2e4a708918e14fdbd534cc94aaa9470cd19b2464",
+        "rev": "11aff801aa0ea1fb02ae43e61f7cdf610f5fe2e5",
         "type": "github"
       },
       "original": {
@@ -1024,17 +1024,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1663862689,
-        "narHash": "sha256-KHsPD/IxsRwUFz5Y2e129PYI4xQcibW3EDskURmT0ew=",
+        "lastModified": 1665485285,
+        "narHash": "sha256-+oGZ1Ie5ZCli29knuAiKH0NlCLS6OSVRgL5y1okt2ds=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "cab2acedc4c730383eda938a4f17e94c63daaddd",
+        "rev": "69c14e4afb1806505af6982433a764d90fa2c644",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "cab2acedc4c730383eda938a4f17e94c63daaddd",
+        "rev": "69c14e4afb1806505af6982433a764d90fa2c644",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/cab2acedc4c730383eda938a4f17e94c63daaddd;
+    primer.url = github:hackworthltd/primer/69c14e4afb1806505af6982433a764d90fa2c644;
   };
 
   outputs =

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,12 @@ processes = []
 
 [env]
 
+[metrics]
+  # Note: this is the same as the service port because the metrics are
+  # also served by WAI.
+  port = 8081
+  path = "/metrics"
+  
 [experimental]
   allowed_public_ports = []
   auto_rollback = true

--- a/src/primer-api/primer-api.ts
+++ b/src/primer-api/primer-api.ts
@@ -205,7 +205,7 @@ export const useGetAvailableActionsHook = () => {
     params: GetAvailableActionsParams
   ) => {
     return getAvailableActions({
-      url: `/openapi/sessions/${sessionId}/action/available/available`,
+      url: `/openapi/sessions/${sessionId}/action/available`,
       method: "post",
       headers: { "Content-Type": "application/json;charset=utf-8" },
       data: selection,
@@ -219,7 +219,7 @@ export const getGetAvailableActionsQueryKey = (
   selection: Selection,
   params: GetAvailableActionsParams
 ) => [
-  `/openapi/sessions/${sessionId}/action/available/available`,
+  `/openapi/sessions/${sessionId}/action/available`,
   ...(params ? [params] : []),
   selection,
 ];


### PR DESCRIPTION
This Primer update includes Prometheus metrics (GHC runtime metrics
only, for now), which Fly.io will scrape and provide to us via their
VictoriaMetrics service.
