### PR TITLE
feat: Add a log shipper for Fly.io deployments.

### DIFF
--- a/.github/workflows/deploy-logging-to-flyio.yaml
+++ b/.github/workflows/deploy-logging-to-flyio.yaml
@@ -1,0 +1,71 @@
+name: Deploy hackworth-codes-logging
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy hackworth-codes-logging
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      deployments: write
+
+    environment:
+      name: production
+      url: https://hackworth-codes-logging.fly.dev/
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3.0.2
+        with:
+          # Required by flakes
+          fetch-depth: 0
+
+      - name: Import secrets from Vault
+        uses: hashicorp/vault-action@v2.4.2
+        id: secrets
+        with:
+          url: https://secrets.hackworth-corp.com
+          path: "github-actions"
+          caCertificate: ${{ secrets.VAULT_CA_CERT }}
+          role: primer-app-workflow-flyio
+          method: jwt
+          secrets: |
+            secret/data/flyio/github token | FLY_API_TOKEN ;
+            secret/data/cachix/hackworthltd-private/github-workflows token | CACHIX_AUTH_TOKEN ;
+
+      - name: Install & configure Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hackworthltd.cachix.org-1:0JTCI0qDo2J+tonOalrSQP3yRNleN6bQucJ05yDltRI= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
+            substituters = https://cache.nixos.org?priority=10 https://hackworthltd.cachix.org?priority=30 https://cache.iog.io?priority=40 https://cache.zw3rk.com?priority=50
+
+      - name: Configure Cachix for private Hackworth Ltd cache
+        uses: cachix/cachix-action@v11
+        with:
+          name: hackworthltd-private
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+
+      - name: Fetch hackworth-codes-logging-docker-image
+        run: |
+          nix build -L .#packages.x86_64-linux.hackworth-codes-logging-docker-image 
+
+      - name: Load Docker image
+        run: |
+          IMAGE=$(docker load --quiet < result | grep -Po 'Loaded image: \Khackworth-codes-logging:.*')
+          LABEL=$(echo "$IMAGE" | grep -Po 'hackworth-codes-logging:\K.*')
+          echo "Loaded Docker image: $IMAGE"
+          echo "docker_image=$IMAGE" >> "$GITHUB_ENV"
+          echo "docker_image_label=$LABEL" >> "$GITHUB_ENV"
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy Docker image
+        run: |
+          flyctl deploy --image "$docker_image" --image-label "$docker_image_label"

--- a/fly/apps/hackworth-codes-logging/fly.toml
+++ b/fly/apps/hackworth-codes-logging/fly.toml
@@ -1,0 +1,12 @@
+app = "hackworth-codes-logging"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[metrics]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true

--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -1,11 +1,15 @@
 { writeShellApplication
 , docker
-, gnugrep
 , flyctl
+, gnugrep
+, hackworth-codes-logging-docker-image
+, primer-app-rev
 , primer-service-docker-image
 , primer-service-rev
 , primer-sqitch
 , procps
+, tailscale
+, vector
 }:
 
 let
@@ -37,8 +41,59 @@ let
     '';
   };
 
+  deploy-hackworth-codes-logging = writeShellApplication {
+    name = "deploy-hackworth-codes-logging";
+    runtimeInputs = [
+      docker
+      flyctl
+      gnugrep
+      primer-sqitch
+      procps
+    ];
+    text = ''
+      IMAGE=$(docker load --quiet < "${hackworth-codes-logging-docker-image}" | grep -Po 'Loaded image: \Khackworth-codes-logging:.*')
+
+      function rm-image() {
+        docker rmi "$IMAGE"
+      }
+      trap rm-image EXIT
+
+      echo "Loaded image: $IMAGE"
+
+      trap 'pkill -P $$; exit' SIGINT SIGTERM
+      flyctl deploy --image "$IMAGE" --image-label "git-${primer-app-rev}"
+    '';
+  };
+
+  # Docker entrypoint for our Hackworth Codes logging service. It uses
+  # Tailscale to communicate with our logging services.
+  #
+  # Note that there are some imperative setup steps required before
+  # this will work. Create a Fly.io app named
+  # `hackworth-codes-logging` and then see this document to configure
+  # Tailscale:
+  #
+  # https://tailscale.com/kb/1132/flydotio/
+  hackworth-codes-logging-entrypoint = writeShellApplication {
+    name = "hackworth-codes-logging-entrypoint";
+    runtimeInputs = [
+      tailscale
+      vector
+    ];
+    text = ''
+      if [ -z ''${TAILSCALE_AUTHKEY+x} ]; then
+        echo "TAILSCALE_AUTHKEY is not set, exiting." >&2
+        exit 1
+      fi
+      tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+      tailscale up --authkey="$TAILSCALE_AUTHKEY" --hostname=hackworth-codes-logging
+      while true; do sleep 10 ; done
+    '';
+  };
 in
 {
   inherit deploy-primer-service;
+  inherit hackworth-codes-logging-entrypoint;
+  inherit deploy-hackworth-codes-logging;
 }
 


### PR DESCRIPTION
This log shipper connects to our Tailscale network ("Tailnet") so that
we can securely ship logs to our logging instance, because a) Loki
doesn't support any form of authentication and b) Cloudflare Access's
token-based auth method for apps isn't supported in Vector, which
we'll be using to ship the logs.

Note that this commit doesn't enable Vector yet. I'm just vetting this
Tailscale mechanism first.
