### PR TITLE
fix: Another attempt to fix Tailscale Magic DNS.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,13 @@
         (final: prev:
           let
           in
-          { }
+          {
+            # For Fly.io Tailscale support, we need a version of
+            # Tailscale that uses `iptables-legacy`.
+            tailscale = final.callPackage ./nix/pkgs/tailscale-iptables-legacy {
+              buildGoModule = final.buildGo119Module;
+            };
+          }
         )
       ];
 

--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -6,7 +6,6 @@
 , formats
 , gnugrep
 , hackworth-codes-logging-docker-image
-, iptables
 , primer-service-docker-image
 , primer-service-rev
 , primer-sqitch
@@ -223,7 +222,6 @@ let
     runtimeInputs = [
       cacert
       coreutils
-      iptables
       tailscale
       vector
     ];

--- a/nix/pkgs/tailscale-iptables-legacy/default.nix
+++ b/nix/pkgs/tailscale-iptables-legacy/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub, makeWrapper, iptables-legacy, iproute2, procps, shadow, getent }:
+
+buildGoModule rec {
+  pname = "tailscale";
+  version = "1.32.0";
+
+  src = fetchFromGitHub {
+    owner = "tailscale";
+    repo = "tailscale";
+    rev = "v${version}";
+    sha256 = "sha256-+pJ7YwJKtlB/UmuvKT4zoWRn1ZBAf75/GcscPbFuA8c=";
+  };
+  vendorSha256 = "sha256-VW6FvbgLcokVGunTCHUXKuH5+O6T55hGIP2g5kFfBsE=";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ makeWrapper ];
+
+  CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
+
+  ldflags = [ "-X tailscale.com/version.Long=${version}" "-X tailscale.com/version.Short=${version}" ];
+
+  doCheck = false;
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/tailscaled --prefix PATH : ${lib.makeBinPath [ iproute2 iptables-legacy getent shadow ]}
+    wrapProgram $out/bin/tailscale --suffix PATH : ${lib.makeBinPath [ procps ]}
+
+    sed -i -e "s#/usr/sbin#$out/bin#" -e "/^EnvironmentFile/d" ./cmd/tailscaled/tailscaled.service
+    install -D -m0444 -t $out/lib/systemd/system ./cmd/tailscaled/tailscaled.service
+  '';
+
+  meta = with lib; {
+    homepage = "https://tailscale.com";
+    description = "The node agent for Tailscale, a mesh VPN built on WireGuard (iptables-legacy version)";
+    license = licenses.bsd3;
+  };
+}
+


### PR DESCRIPTION
Here we try building Tailscale with "legacy" iptables (i.e., without
NFT support). I'm trying this because we're getting this in the Fly.io
container logs:

```
2022-10-18T17:09:11.977 app[60f27ac5] lhr [info] 2022/10/18 17:09:11 health("router"): error: setting up filter/ts-input: running [/nix/store/c0kw86sjk4lpp5vv3wbp0m9q6pj5dyj9-iptables-1.8.8/bin/iptables -t filter -N ts-input --wait]: exit status 4: iptables v1.8.8 (nf_tables): Could not fetch rule set generation id: Invalid argument
```

which is indicative of a mismatch between iptables compiled with NFT
support and a kernel that doesn't use NFT. (Seems plausible that
Fly.io's host kernels don't use NFT, I guess.)
