### PR TITLE
build: pnpm watch runs eslint

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,9 @@ export default ({ mode }) => {
       checker({
         typescript: true,
         overlay: false,
+        eslint: {
+          lintCommand: "eslint .",
+        },
       }),
       react(),
       svgr(),


### PR DESCRIPTION
This was disabled in 3da882efeef959aea39494141d8332e4ae5e2365 due to problems with a multi-package monorepo and yarn. We no longer use either of these things, so we can re-enable this feature (in line with what README.md claims).