### PR TITLE
chore: opt out of storybook's telemetry

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,6 +13,7 @@ const config: StorybookViteConfig = {
   addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
   core: {
     builder: "@storybook/builder-vite",
+    disableTelemetry: true,
   },
 
   // storybook-builder-vite doesn't read the project's vite.config.js,


### PR DESCRIPTION
Modern Storybook by default collects some telemetry: https://storybook.js.org/telemetry/