### PR TITLE
fix: Remove Vite optimizeDeps stanza.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,16 +99,5 @@
       "glob-parent@<5.1.2": ">=5.1.2",
       "d3-color@<3.1.0": ">=3.1.0"
     }
-  },
-  "vite": {
-    "optimizeDeps": {
-      "include": [
-        "axios",
-        "react",
-        "react-dom",
-        "react-query",
-        "react-router-dom"
-      ]
-    }
   }
 }


### PR DESCRIPTION
This is a leftover from our monorepo days, and should not be necessary
anymore, as far as I understand it.

This *may* be a fix for the interactive Storybook issue I've been
experiencing:

https://github.com/hackworthltd/primer-app/pull/682#issue-1487657638
