### PR TITLE
fix: Workaround for https://github.com/dominikg/tsconfck/issues/74.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -243,10 +243,10 @@
               export PATH="$(pwd)/node_modules/.bin:$PATH"
 
               if ! type -P pnpm ; then
-                npx pnpm install
+                npx pnpm add pnpm
+              else
+                pnpm install
               fi
-
-              pnpm install
 
               rm -f ${local-spec}
               ln -s ${spec} ${local-spec}


### PR DESCRIPTION
We get `npx` from nixpkgs and use it to install pnpm, but it appears that currently installs pnpm 7.17.0, which is now too old for `tsconfck` (which we're not even using, it's a dependency of a dependency, sigh), which complains about the version of `pnpm` we're using, even though we're not building that package, we're just using it as a dependency!

@brprice figured out this workaround, which is fine with me.