### PR TITLE
ci: Run build first, and only then subsequent workflows.

### DIFF
--- a/.github/workflows/build-primer-app.yaml
+++ b/.github/workflows/build-primer-app.yaml
@@ -1,7 +1,15 @@
+# Note: this workflow is a dependency of several other workflows in
+# this repo. Those workflows are triggered via the name of this
+# workflow, so don't change the name here without also changing it in
+# all of its dependent workflows!
+
 name: Build the frontend
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build-frontend:

--- a/.github/workflows/deploy-logging-to-flyio.yaml
+++ b/.github/workflows/deploy-logging-to-flyio.yaml
@@ -1,12 +1,21 @@
 name: Deploy hackworth-codes-logging
+
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Build the frontend
+    types:
+      - completed
     branches:
       - main
+
 jobs:
   deploy:
     name: Deploy hackworth-codes-logging
     runs-on: ubuntu-latest
+
+    # Only run if the triggering workflow was successful.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     permissions:
       contents: read

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -1,7 +1,11 @@
 name: Deploy Storybook.js
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Build the frontend
+    types:
+      - completed
     branches-ignore:
       # Do not run this workflow on Dependabot updates, or else it'll
       # absolutely kill our GitHub Action & Chromatic CI minutes.
@@ -13,6 +17,9 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+
+    # Only run if the triggering workflow was successful.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/deploy-to-cf-pages.yaml
+++ b/.github/workflows/deploy-to-cf-pages.yaml
@@ -1,7 +1,11 @@
 name: Deploy frontend to Cloudflare Pages
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Build the frontend
+    types:
+      - completed
 
 jobs:
   build:
@@ -10,6 +14,9 @@ jobs:
       id-token: write
       deployments: write
     runs-on: ubuntu-latest
+
+    # Only run if the triggering workflow was successful.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/deploy-to-flyio.yaml
+++ b/.github/workflows/deploy-to-flyio.yaml
@@ -1,12 +1,20 @@
 name: Deploy primer-service
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Build the frontend
+    types:
+      - completed
     branches:
       - main
+
 jobs:
   deploy:
     name: Deploy primer-service
     runs-on: ubuntu-latest
+
+    # Only run if the triggering workflow was successful.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     permissions:
       contents: read


### PR DESCRIPTION
Rather than launching everything in parallel, we now:

1. Run the "Build the frontend" workflow, which boils down to `pnpm build`.

2. Run all other workflows in parallel, with the following caveats:

- The dependent workflows only run if the "Build the frontend" workflow was successful.

- The deployment workflows only run if the "Build the frontend" workflow was run on `main`.