### PR TITLE
ci: Deploy each component to a separately-named environment.

### DIFF
--- a/.github/workflows/build-primer-app.yaml
+++ b/.github/workflows/build-primer-app.yaml
@@ -71,6 +71,11 @@ jobs:
           secrets: |
             secret/data/cloudflare/primer-app api-token | CLOUDFLARE_API_TOKEN ;
 
+      # Not only does this action deploy to Cloudflare Pages, it also
+      # creates a GitHub environment (and corresponding deployment).
+      # For PRs, this environment will be named "Preview
+      # :(name-of-branch)". For merges to `main`, it'll be named
+      # "Production". These names do not appear to be configurable.
       - name: Deploy to Cloudflare
         uses: cloudflare/pages-action@v1.3.0
         with:

--- a/.github/workflows/deploy-logging-to-flyio.yaml
+++ b/.github/workflows/deploy-logging-to-flyio.yaml
@@ -31,8 +31,8 @@ jobs:
       deployments: write
 
     environment:
-      name: production
-      url: https://hackworth-codes-logging.fly.dev/
+      name: "Production (logging)"
+      url: https://fly.io/apps/hackworth-codes-logging
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/deploy-to-flyio.yaml
+++ b/.github/workflows/deploy-to-flyio.yaml
@@ -31,8 +31,8 @@ jobs:
       deployments: write
 
     environment:
-      name: production
-      url: https://hackworth-code.fly.dev/
+      name: "Production (service)"
+      url: https://fly.io/apps/hackworth-code
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
For each merge to `main`, we perform 3 different deployments, each to
a different component of the production service:

* The frontend code (to Cloudflare Pages);

* The backend service (to a Fly.io app named hackworth-code).

* The backend logging service (to a Fly.io app named
hackworth-codes-logging).

Prior to this commit, our GitHub CI workflows created the following
environments (and deployments):

* "Production", via the cloudflare/pages-action GitHub Action.

* "production", for both Fly.io deployments.

This commit creates a different environment for each Fly.io
deployment, one named "Production (logging)", and the other named
"Production (service)". This will make it possible to track each
deployment separately in the GitHub UI.

(Note that we have no control over the environment name used by the
cloudflare/pages-action, as far as I can tell.)
