### PR TITLE
fix: Revert accidental node width change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,7 +241,7 @@ const AppNoError = ({
         defs={p.module.defs}
         forestLayout="Horizontal"
         treePadding={100}
-        nodeWidth={90}
+        nodeWidth={150}
         nodeHeight={50}
         boxPadding={50}
       />


### PR DESCRIPTION
This was accidentally staged as part of #769.

I've had that change laying around in my working directory for a while. It is probably a better default for now while we're not showing module names. But I intend to look in to dynamic sizing soon-ish anyway.