### PR TITLE
feat: saturated constructors

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-dd3d369b48f2fa81feadb0b8f02e7f06385b3208
+          image: ghcr.io/hackworthltd/primer-service-dev:git-2ff4cb51e9276909b4b3b622d4f2a4b313fc3dcb
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1678379998,
-        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
         "type": "github"
       },
       "original": {
@@ -380,11 +380,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1677714448,
-        "narHash": "sha256-Hq8qLs8xFu28aDjytfxjdC96bZ6pds21Yy09mSC156I=",
+        "lastModified": 1682984683,
+        "narHash": "sha256-fSMthG+tp60AHhNmaHc4StT3ltfHkQsJtN8GhfLWmtI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dc531e3a9ce757041e1afaff8ee932725ca60002",
+        "rev": "86684881e184f41aa322e653880e497b66429f3e",
         "type": "github"
       },
       "original": {
@@ -440,15 +440,16 @@
     },
     "flake-utils_4": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
+        "lastModified": 1679360468,
+        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
+        "owner": "hamishmack",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -677,11 +678,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1678494185,
-        "narHash": "sha256-O3UHAguJwdG7maUakbLjHhCLtsTtI3X6g3kAHoI5cRU=",
+        "lastModified": 1683851207,
+        "narHash": "sha256-lBBjRTh5ezXclNkzebFcP1ILB+jf9JTnH2gV0GAfOb0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "2974e3b444eb8680d52adfcc6b9f23d9614e2ad7",
+        "rev": "650715b168432b53d9210049274632e6e798c259",
         "type": "github"
       },
       "original": {
@@ -730,16 +731,33 @@
         "sops-nix": "sops-nix_2"
       },
       "locked": {
-        "lastModified": 1678040136,
-        "narHash": "sha256-ViJx7BQWqVv6cGC/4yzNRR47eqRycT5OdInCVYlQRfA=",
+        "lastModified": 1683366136,
+        "narHash": "sha256-swY9PgRDO1/M6DuZVZvRT+06vAkzcynTUHB7BuKRMnU=",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "15059d330237066bc643f87f563f3b0e190ab53b",
+        "rev": "201915c4744a2048a431bfb5edd2fd3c305fd131",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "hacknix",
+        "type": "github"
+      }
+    },
+    "haskell-language-server": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682523907,
+        "narHash": "sha256-2iLUGL4l9gIFmdRZpmnnUmGe14N8eDf7Ytq8zuwk2X0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "cda1325241365896f24d1a09899b8e8e787f9c7b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "cda1325241365896f24d1a09899b8e8e787f9c7b",
         "type": "github"
       }
     },
@@ -754,6 +772,7 @@
         "flake-utils": "flake-utils_4",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
+        "hls-1.10": "hls-1.10",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -773,16 +792,33 @@
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1678495836,
-        "narHash": "sha256-y4FzKmY+nLLD6CrXxNsK/dMQJtO1KpcRagVs5XzjHdo=",
+        "lastModified": 1683869096,
+        "narHash": "sha256-7R2yL3LQNfCLMbNzOWID6j02iPA9KYOhnQmbZKGWv94=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "02394687c4ae19c9d660fd247f11d0bafe2bc132",
+        "rev": "2b1f3bccaef9ad4e7e947256609f8e9e0a533dc6",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -958,11 +994,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "lastModified": 1682773107,
+        "narHash": "sha256-+h94XeJnG3uk5imJlBi/1lVmcfCbxHpwZp5u7n3Krwg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "rev": "379d42fad6bc5c28f79d5f7ff2fa5f1c90cb7bf8",
         "type": "github"
       },
       "original": {
@@ -1083,11 +1119,11 @@
     },
     "nixlib_2": {
       "locked": {
-        "lastModified": 1677373009,
-        "narHash": "sha256-kxhz4QUP8tXa/yVSpEzDDZSEp9FvhzRqZzb+SeUaekw=",
+        "lastModified": 1681001314,
+        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c9d4f2476046c6a7a2ce3c2118c48455bf0272ea",
+        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
         "type": "github"
       },
       "original": {
@@ -1128,11 +1164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677834279,
-        "narHash": "sha256-JHKdz4+KtDcCuIxt7jl03/wv3gMVCN5cHuED7SYS75c=",
+        "lastModified": 1683189539,
+        "narHash": "sha256-dqeE6PM1SSNCB9BSBgh/9dJPLn3sf7P4uay8/CymMlQ=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "59d63c5bb0574048d3519c268fccf73e57220bf5",
+        "rev": "104ca15b0019bf461639050daeaa18e25642ccee",
         "type": "github"
       },
       "original": {
@@ -1205,11 +1241,11 @@
     },
     "nixpkgs-2205": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1682600000,
+        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
         "type": "github"
       },
       "original": {
@@ -1221,11 +1257,11 @@
     },
     "nixpkgs-2211": {
       "locked": {
-        "lastModified": 1675730325,
-        "narHash": "sha256-uNvD7fzO5hNlltNQUAFBPlcEjNG5Gkbhl/ROiX+GZU4=",
+        "lastModified": 1682682915,
+        "narHash": "sha256-haR0u/j/nUvlMloYlaOYq1FMXTvkNHw+wGxc+0qXisM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7ce17b1ebf600a72178f6302c77b6382d09323f",
+        "rev": "09f1b33fcc0f59263137e23e935c1bb03ec920e4",
         "type": "github"
       },
       "original": {
@@ -1274,11 +1310,11 @@
     "nixpkgs-lib_3": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1678375444,
-        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
         "type": "github"
       },
       "original": {
@@ -1292,11 +1328,11 @@
     "nixpkgs-lib_4": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1677407201,
-        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
         "type": "github"
       },
       "original": {
@@ -1373,11 +1409,11 @@
     },
     "nixpkgs-stable_4": {
       "locked": {
-        "lastModified": 1673800717,
-        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
         "type": "github"
       },
       "original": {
@@ -1389,11 +1425,11 @@
     },
     "nixpkgs-stable_5": {
       "locked": {
-        "lastModified": 1677560965,
-        "narHash": "sha256-Tqwt5alTtMnbYUPKCYRYZqlfbjprLgDWqjMhXpFMQ6k=",
+        "lastModified": 1682817260,
+        "narHash": "sha256-kFMXzKNj4d/0Iqbm5l57rHSLyUeyCLMuvlROZIuuhvk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40968a3aa489191cf4b7ba85cf2a54d8a75c8daa",
+        "rev": "db1e4eeb0f9a9028bcb920e00abbc1409dd3ef36",
         "type": "github"
       },
       "original": {
@@ -1405,11 +1441,11 @@
     },
     "nixpkgs-stable_6": {
       "locked": {
-        "lastModified": 1673800717,
-        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
         "type": "github"
       },
       "original": {
@@ -1421,11 +1457,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1675758091,
-        "narHash": "sha256-7gFSQbSVAFUHtGCNHPF7mPc5CcqDk9M2+inlVPZSneg=",
+        "lastModified": 1682656005,
+        "narHash": "sha256-fYplYo7so1O+rSQ2/aS+SbTPwLTeoUXk4ekKNtSl4P8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "747927516efcb5e31ba03b7ff32f61f6d47e7d87",
+        "rev": "6806b63e824f84b0f0e60b6d660d4ae753de0477",
         "type": "github"
       },
       "original": {
@@ -1622,11 +1658,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1677832802,
-        "narHash": "sha256-XQf+k6mBYTiQUjWRf/0fozy5InAs03O1b30adCpWeXs=",
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "382bee738397ca005206eefa36922cc10df8a21c",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
         "type": "github"
       },
       "original": {
@@ -1647,11 +1683,11 @@
         "nixpkgs-stable": "nixpkgs-stable_6"
       },
       "locked": {
-        "lastModified": 1678376203,
-        "narHash": "sha256-3tyYGyC8h7fBwncLZy5nCUjTJPrHbmNwp47LlNLOHSM=",
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1a20b9708962096ec2481eeb2ddca29ed747770a",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
         "type": "github"
       },
       "original": {
@@ -1665,6 +1701,7 @@
         "flake-compat": "flake-compat_5",
         "flake-parts": "flake-parts_3",
         "hacknix": "hacknix_2",
+        "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix",
         "nixpkgs": [
           "primer",
@@ -1674,17 +1711,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1680628369,
-        "narHash": "sha256-tjHhy4Ob+ntXBv3BQkFniScq+R9w/ch1ZrIUl7pkHoc=",
+        "lastModified": 1684250002,
+        "narHash": "sha256-RSWy9uRofUGOuWVCRM2RuhgQR591jyQY2wG4hFIOIg8=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "dd3d369b48f2fa81feadb0b8f02e7f06385b3208",
+        "rev": "2ff4cb51e9276909b4b3b622d4f2a4b313fc3dcb",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "dd3d369b48f2fa81feadb0b8f02e7f06385b3208",
+        "rev": "2ff4cb51e9276909b4b3b622d4f2a4b313fc3dcb",
         "type": "github"
       }
     },
@@ -1734,11 +1771,11 @@
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
-        "lastModified": 1677833841,
-        "narHash": "sha256-yHZFGe7dhBE43FFWKiWc29NuveH+nfyTT6oKyFDEMys=",
+        "lastModified": 1682823324,
+        "narHash": "sha256-KNu3OAqVyoKwnDP+gqptjQYCnZXxEwXccR89c0r1/8k=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "128e9b29ddd88ceb634a28f7dbbfee7b895f005f",
+        "rev": "4f308f76633f81253a12b80e7b05b80d325005b2",
         "type": "github"
       },
       "original": {
@@ -1750,11 +1787,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1678493393,
-        "narHash": "sha256-RfZsYHaD1jOdBx0CneMMl0vwIy91A/H4BJs7aMvph40=",
+        "lastModified": 1683850134,
+        "narHash": "sha256-qlo28IOzYgPsFypHNi/1Zgxf4Ei5P8XbUCDDM9Ldywg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "24ea8d4a9de68d38b688c6bb391da49d8c2f8153",
+        "rev": "69b95b574515c4c083d36f1a29f85aa482e37d5d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/dd3d369b48f2fa81feadb0b8f02e7f06385b3208;
+    primer.url = github:hackworthltd/primer/2ff4cb51e9276909b4b3b622d4f2a4b313fc3dcb;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };

--- a/src/Actions.tsx
+++ b/src/Actions.tsx
@@ -47,9 +47,7 @@ export const actionName = (
     case "DeleteType":
       return prose("⌫");
     case "MakeCon":
-      return code("V");
-    case "MakeConSat":
-      return code("V $ ?");
+      return code("V ? ?");
     case "MakeInt":
       return code("1");
     case "MakeChar":
@@ -139,8 +137,6 @@ export const actionDescription = (
       return "Delete this type";
     case "MakeCon":
       return "Use a value constructor";
-    case "MakeConSat":
-      return "Apply a value constructor to arguments";
     case "MakeInt":
       return "Insert a whole number";
     case "MakeChar":
@@ -215,8 +211,6 @@ export const actionType = (action: NoInputAction | InputAction): ActionType => {
     case "DeleteType":
       return "Destructive";
     case "MakeCon":
-      return "Primary";
-    case "MakeConSat":
       return "Primary";
     case "MakeInt":
       return "Primary";

--- a/src/components/TreeReactFlow/Flavor.ts
+++ b/src/components/TreeReactFlow/Flavor.ts
@@ -177,8 +177,6 @@ export const flavorClasses = (flavor: NodeFlavor): string => {
         "hover:ring-blue-quaternary",
         commonHoverClasses
       );
-    case "PatternApp":
-      return "border-blue-tertiary ring-blue-tertiary bg-blue-tertiary";
   }
 };
 
@@ -238,8 +236,6 @@ export const flavorContentClasses = (
       return "text-blue-primary";
     case "PatternBind":
       return "text-blue-primary";
-    case "PatternApp":
-      return "text-white-primary";
   }
 };
 
@@ -299,8 +295,6 @@ export const flavorLabelClasses = (flavor: NodeFlavor): string => {
       return "bg-green-primary border-green-primary text-white-primary";
     case "PatternBind":
       return "bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "PatternApp":
-      return "font-code bg-blue-tertiary border-blue-tertiary text-white-primary";
   }
 };
 
@@ -360,8 +354,6 @@ export const flavorEdgeClasses = (flavor: NodeFlavor): string => {
       return "stroke-green-primary";
     case "PatternBind":
       return "stroke-blue-quaternary";
-    case "PatternApp":
-      return "stroke-blue-tertiary";
   }
 };
 
@@ -421,8 +413,6 @@ export const flavorLabel = (flavor: NodeFlavor): string => {
       return "V";
     case "PatternBind":
       return "Var";
-    case "PatternApp":
-      return "$";
   }
 };
 
@@ -442,8 +432,6 @@ export const noBodyFlavorContents = (flavor: NodeFlavorNoBody): string => {
       return "function type";
     case "TApp":
       return "apply type";
-    case "PatternApp":
-      return "apply";
     case "Hole":
       return "{?}";
     case "EmptyHole":

--- a/src/components/examples/trees.ts
+++ b/src/components/examples/trees.ts
@@ -461,24 +461,16 @@ export const oddEvenTrees: [string, Tree][] = [
                       fst: "Pattern",
                       snd: {
                         body: {
-                          tag: "NoBody",
-                          contents: "PatternApp",
+                          contents: {
+                            fst: "PatternCon",
+                            snd: {
+                              baseName: "Succ",
+                              qualifiedModule: ["Builtins"],
+                            },
+                          },
+                          tag: "TextBody",
                         },
                         childTrees: [
-                          {
-                            body: {
-                              contents: {
-                                fst: "PatternCon",
-                                snd: {
-                                  baseName: "Succ",
-                                  qualifiedModule: ["Builtins"],
-                                },
-                              },
-                              tag: "TextBody",
-                            },
-                            childTrees: [],
-                            nodeId: "15P1B",
-                          },
                           {
                             body: {
                               contents: {
@@ -491,7 +483,7 @@ export const oddEvenTrees: [string, Tree][] = [
                             nodeId: "18",
                           },
                         ],
-                        nodeId: "18A",
+                        nodeId: "15P1B",
                       },
                     },
                     tag: "BoxBody",
@@ -605,22 +597,17 @@ export const oddEvenTreesMiscStyles: [string, Tree][] = [
                 contents: {
                   fst: "Pattern",
                   snd: {
-                    body: { tag: "NoBody", contents: "PatternApp" },
-                    childTrees: [
-                      {
-                        body: {
-                          contents: {
-                            fst: "PatternCon",
-                            snd: {
-                              baseName: "Succ",
-                              qualifiedModule: ["Builtins"],
-                            },
-                          },
-                          tag: "TextBody",
+                    body: {
+                      contents: {
+                        fst: "PatternCon",
+                        snd: {
+                          baseName: "Succ",
+                          qualifiedModule: ["Builtins"],
                         },
-                        childTrees: [],
-                        nodeId: "4P1B",
                       },
+                      tag: "TextBody",
+                    },
+                    childTrees: [
                       {
                         body: {
                           contents: {
@@ -633,7 +620,7 @@ export const oddEvenTreesMiscStyles: [string, Tree][] = [
                         nodeId: "7",
                       },
                     ],
-                    nodeId: "7A",
+                    nodeId: "4P1B",
                   },
                 },
                 tag: "BoxBody",

--- a/src/primer-api/model/getActionOptionsAction.ts
+++ b/src/primer-api/model/getActionOptionsAction.ts
@@ -12,7 +12,6 @@ export type GetActionOptionsAction = typeof GetActionOptionsAction[keyof typeof 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GetActionOptionsAction = {
   MakeCon: 'MakeCon',
-  MakeConSat: 'MakeConSat',
   MakeInt: 'MakeInt',
   MakeChar: 'MakeChar',
   MakeVar: 'MakeVar',

--- a/src/primer-api/model/inputAction.ts
+++ b/src/primer-api/model/inputAction.ts
@@ -12,7 +12,6 @@ export type InputAction = typeof InputAction[keyof typeof InputAction];
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const InputAction = {
   MakeCon: 'MakeCon',
-  MakeConSat: 'MakeConSat',
   MakeInt: 'MakeInt',
   MakeChar: 'MakeChar',
   MakeVar: 'MakeVar',

--- a/src/primer-api/model/nodeFlavorNoBody.ts
+++ b/src/primer-api/model/nodeFlavorNoBody.ts
@@ -18,7 +18,6 @@ export const NodeFlavorNoBody = {
   APP: 'APP',
   Case: 'Case',
   CaseWith: 'CaseWith',
-  PatternApp: 'PatternApp',
   TEmptyHole: 'TEmptyHole',
   THole: 'THole',
   TFun: 'TFun',


### PR DESCRIPTION
This mostly involves simply bumping the primer pin to a version which
has saturated constructors. However there are some small changes for
compatibility: we remove references to no-longer existing 'MakeCon'
action and 'PatternApp' flavor, which used to be exposed in primer's
OpenAPI, but no longer exist.
