### PR TITLE
chore(primer): Bump Primer pin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ To develop interactively, enter the Nix shell via `nix develop`, which will inst
 In most circumstances, while developing locally, you'll want to launch the version of `primer-service` that is pinned via this repo's `primer` Nix flake input. To do that, run the following command from this project's top-level directory:
 
 ```sh
-nix run .#run-primer
+nix run .#run-primer-sqlite
 ```
-
-Note that this only works if there's also a local PostgreSQL Docker instance running. Because we expect that developers will generally always be running this PostgreSQL instance, we haven't bothered to include the related Docker helper scripts from the Primer repo in this repo. See the [Primer repo's README file](https://github.com/hackworthltd/primer/blob/main/README.md#local-development) for details on how to manage the PostgreSQL Docker instance.
 
 ### Scripts
 

--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1675933616,
-        "narHash": "sha256-/rczJkJHtx16IFxMmAWu5nNYcSXNg1YYXTHoGjLrLUA=",
+        "lastModified": 1677714448,
+        "narHash": "sha256-Hq8qLs8xFu28aDjytfxjdC96bZ6pds21Yy09mSC156I=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "47478a4a003e745402acf63be7f9a092d51b83d7",
+        "rev": "dc531e3a9ce757041e1afaff8ee932725ca60002",
         "type": "github"
       },
       "original": {
@@ -1238,11 +1238,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1675183161,
-        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
+        "lastModified": 1677407201,
+        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
+        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
         "type": "github"
       },
       "original": {
@@ -1596,11 +1596,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1677160285,
-        "narHash": "sha256-tBzpCjMP+P3Y3nKLYvdBkXBg3KvTMo3gvi8tLQaqXVY=",
+        "lastModified": 1677832802,
+        "narHash": "sha256-XQf+k6mBYTiQUjWRf/0fozy5InAs03O1b30adCpWeXs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2bd861ab81469428d9c823ef72c4bb08372dd2c4",
+        "rev": "382bee738397ca005206eefa36922cc10df8a21c",
         "type": "github"
       },
       "original": {
@@ -1674,17 +1674,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1677456472,
-        "narHash": "sha256-0siKXuegm5NdZuS2fWeA7wgO1nKFLJ+glki3lXs+d8Q=",
+        "lastModified": 1677866888,
+        "narHash": "sha256-rZlMu/TaCynLVmVHcPw7L92fvzHwzWCiX7p/L6nZh3s=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "af0fc5a6a3511f28d6e58ec5961de235091ecdc9",
+        "rev": "daabf2d772fb76c452dd5a354fbbd8275b0ace6f",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "af0fc5a6a3511f28d6e58ec5961de235091ecdc9",
+        "rev": "daabf2d772fb76c452dd5a354fbbd8275b0ace6f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/af0fc5a6a3511f28d6e58ec5961de235091ecdc9;
+    primer.url = github:hackworthltd/primer/daabf2d772fb76c452dd5a354fbbd8275b0ace6f;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
@@ -164,7 +164,7 @@
             let
             in
             {
-              inherit (primerPackages) run-primer primer-openapi-spec primer-sqitch;
+              inherit (primerPackages) run-primer-postgresql run-primer-sqlite primer-openapi-spec primer-sqitch;
             } // (pkgs.lib.optionalAttrs (system == "x86_64-linux") {
               inherit (primerPackages) primer-service-docker-image;
               inherit (scripts) deploy-primer-service deploy-hackworth-codes-logging;
@@ -182,7 +182,7 @@
             in
             (pkgs.lib.mapAttrs (name: pkg: mkApp pkg name) {
               inherit (scripts) deploy-primer-service deploy-hackworth-codes-logging;
-              inherit (primerPackages) run-primer primer-openapi-spec primer-sqitch;
+              inherit (primerPackages) run-primer-postgresql run-primer-sqlite primer-openapi-spec primer-sqitch;
             });
 
           devShells.default = pkgs.mkShell {


### PR DESCRIPTION
This upstream now includes SQLite support. For the time being, we
still deploy to Fly.io with a PostgreSQL backend, but I'd like to test
the new Docker entrypoint script in upstream, with the existing
backend, before we make a major database change.
