### PR TITLE
feat: Add a Kustomize deployment for use by our Argo CD server.

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -1,0 +1,3 @@
+This directory contains a Kustomize app, which is automatically
+installed by our Argo CD server whenever a PR is created and the right
+conditions are satisfied.

--- a/argocd/base/service.yaml
+++ b/argocd/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: primer-service
+  labels:
+    app.kubernetes.io/name: primer-service
+spec:
+  ports:
+    - name: http
+      port: 8081
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: primer-service

--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -1,0 +1,31 @@
+# Note:
+#
+# This StatefulSet does not make any persistent volume claims, as it's
+# intended to be used only for testing. Therefore, the SQLite database
+# it creates will be created in ephemeral node storage. You should not
+# use this manifest for a production service!
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: primer-service
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: primer-service
+  serviceName: "primer-service"
+  replicas: 1
+  minReadySeconds: 20
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: primer-service
+    spec:
+      terminationGracePeriodSeconds: 20
+      containers:
+        - name: primer-service
+          image: ghcr.io/hackworthltd/primer-service:git-805b24098f731f9bd88179404596c9da2007fdd4
+          ports:
+            - containerPort: 8081
+          env:
+            - name: SQLITE_DB
+              value: primer.sqlite3

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -1,0 +1,10 @@
+# Note: namespace will be set by Argo CD when it runs Kustomize to
+# install the app, so we don't set it here. (We can't know what the
+# namespace will be, in any case, as it depends on the PR number.)
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./base/service.yaml
+  - ./base/statefulset.yaml


### PR DESCRIPTION
When Argo CD is properly configured, it will look for this directory
on each PR and, if certain conditions are met on the PR, deploy the
this application into our Kubernetes cluster.

Note that this Kustomize app is intended only for testing, and is not
a complete & proper installation of the `primer-service` service.
