### PR TITLE
feat: Add rounded edges to definition name node

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -191,6 +191,7 @@ const nodeTypes = {
       <div
         className={classNames(
           "flex items-center justify-center",
+          "rounded-md",
           "bg-grey-primary",
           "border-8 border-grey-tertiary ring-grey-tertiary",
           p.data.selected && "ring-4 ring-offset-4",


### PR DESCRIPTION
I don't really know why I didn't do this in the first place.