### PR TITLE
fix: Deploy frontend on pushes to GitHub merge queue branches.

### DIFF
--- a/.github/workflows/deploy-primer-app.yaml
+++ b/.github/workflows/deploy-primer-app.yaml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - gh-readonly-queue/*
 
 jobs:
   deploy-frontend:


### PR DESCRIPTION
We can't just deploy the frontend on pushes to main: we must also
deploy on pushes to GitHub merge queue branches, as well, or else the
merge queue can never satisfy the required status check.
