### PR TITLE
fix: Fix merge queue build.

### DIFF
--- a/.github/workflows/deploy-primer-app-pr.yaml
+++ b/.github/workflows/deploy-primer-app-pr.yaml
@@ -9,6 +9,7 @@ name: Deploy a frontend PR test environment
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   deploy-frontend:

--- a/.github/workflows/deploy-primer-app.yaml
+++ b/.github/workflows/deploy-primer-app.yaml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - main
-      - gh-readonly-queue/*
 
 jobs:
   deploy-frontend:


### PR DESCRIPTION
The previous commit was broken for 2 reasons:

1. It would have deployed a merge queue build to the production site!
We don't want that, for obvious reasons.

2. It didn't work anyway, because the workflow event for the merge
queue isn't `branches:gh-readonly-queue/*`, it's `merge-group:`.
