### PR TITLE
feat: Set higher eval limit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,7 +182,7 @@ const AppNoError = ({
     useEvalFull(
       p.sessionId,
       { qualifiedModule: p.module.modname, baseName: evalTarget || "" },
-      treeParams,
+      { stepLimit: 100, ...treeParams },
       { query: { enabled: !!evalTarget } }
     ),
     [p.module]


### PR DESCRIPTION
The backend [sets this to 10 by default](https://github.com/hackworthltd/primer/blob/9022c69e60edbb3d772720e18857fd7c6b9cec85/primer/src/Primer/API.hs#L1013), which is arbitrary and very low. In the short-term, in the absence of a UI element for configuring this way of configuring this, I propose that we at least set a higher limit, so that we can start to run interesting programs.