### PR TITLE
fix: Set initial floating toolbar position to upper right of canvas.

### DIFF
--- a/src/components/FloatingToolbar/FloatingToolbar.stories.tsx
+++ b/src/components/FloatingToolbar/FloatingToolbar.stories.tsx
@@ -6,6 +6,10 @@ export default {
   title: "Application/Component Library/FloatingToolbar",
   component: FloatingToolbar,
   argTypes: {
+    initialPosition: {
+      description: "The toolbar's initial position.",
+      control: "object",
+    },
     onModeChange: {
       description: 'The event handler for the "Mode" button.',
       action: "mode",
@@ -25,6 +29,16 @@ export default {
   },
 } as ComponentMeta<typeof FloatingToolbar>;
 
-export const Default: ComponentStory<typeof FloatingToolbar> = (
+const Template: ComponentStory<typeof FloatingToolbar> = (
   args: FloatingToolbarProps
-) => <FloatingToolbar {...args} initialMode="tree" />;
+) => (
+  <div>
+    <FloatingToolbar {...args} />
+  </div>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  initialMode: "tree",
+  initialPosition: { x: 100, y: 50 },
+};

--- a/src/components/FloatingToolbar/index.tsx
+++ b/src/components/FloatingToolbar/index.tsx
@@ -10,6 +10,7 @@ import { MouseEventHandler, useRef, useState } from "react";
 import { useDraggable, DragOptions } from "@neodrag/react";
 
 export type FloatingToolbarProps = {
+  initialPosition: { x: number; y: number };
   initialMode: Mode;
   onModeChange: (
     mode: Mode,
@@ -50,6 +51,7 @@ export const FloatingToolbar = (p: FloatingToolbarProps): JSX.Element => {
 
   const draggableRef = useRef(null);
   const options: DragOptions = {
+    defaultPosition: p.initialPosition,
     cancel: "button",
     bounds: "parent",
     onDragStart: (_) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { RefObject, useMemo, useSyncExternalStore } from "react";
+
 /** Evaluates to the type `true` when both parameters are equal, and `false` otherwise.
  * NB. this actually tests mutual extendability, which is mostly a reasonable definition of
  * of equality, but does mean that, for example, `any` is "equal to" everything, except `never`.
@@ -15,3 +17,20 @@ export type Equal<T, S> = [T] extends [S]
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
 export const assertType = <T extends true>() => {};
+
+function subscribe(callback: (e: Event) => void) {
+  window.addEventListener("resize", callback);
+  return () => {
+    window.removeEventListener("resize", callback);
+  };
+}
+
+export function useDimensions(ref: RefObject<HTMLElement>) {
+  const dimensions = useSyncExternalStore(subscribe, () =>
+    JSON.stringify({
+      width: ref.current?.offsetWidth ?? 0,
+      height: ref.current?.offsetHeight ?? 0,
+    })
+  );
+  return useMemo(() => JSON.parse(dimensions), [dimensions]);
+}


### PR DESCRIPTION
To do this, we need to read the dimensions of the canvas `div`
element. There are many, many ways to do this, but none of them are
built-in to React, as such. This Stack Overflow thread is very
helpful (perhaps overly so):

https://stackoverflow.com/questions/43817118/how-to-get-the-width-of-a-react-element

IMO, the two most promising solutions mentioned there were to use the
`use-resize-observer` package:

https://stackoverflow.com/a/71918509

and to use a React 18 technique that is apparently a more modern
approach than using `useEffect` in situations like this one:

https://stackoverflow.com/a/75101934

I settled for the latter, because the amount of code needed to
implement is is very small. However, if in the future we run into
problems with browser compatibility or needing more features, we might
want to look into `use-resize-observer`.

For an explanation of why the dimensions object is string-ified, see
the Stack Overflow referenced answer. Basically, it's due to `===` not
working as you'd expect, and hopefully will be fixed in later versions
of React so that it's not necessary.

Note that per the Stack Overflow terms of service, the code in the
answer we've used is licensed under CC BY-SA 4.0. See:

https://stackoverflow.com/help/licensing
https://creativecommons.org/licenses/by-sa/4.0/
https://creativecommons.org/licenses/by-sa/4.0/legalcode

Per the terms of the license, we must document any changes we made to
the original implementation. The changes are:

* Replace `export { useDimensions }` in the original with an inline
export.

* Reformat the code using our Prettier settings.
