### PR TITLE
ci: add a DCO check

### DIFF
--- a/.github/workflows/check-dco.yaml
+++ b/.github/workflows/check-dco.yaml
@@ -1,0 +1,21 @@
+name: Check DCO
+
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  check-dco:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
+      statuses: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check DCO
+        uses: hackworthltd/dcoapp@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,7 @@
               };
 
               excludes = [
+                "DCO.md"
                 "README.md"
                 "package.json"
                 "pnpm-lock.yaml"


### PR DESCRIPTION
This is required for third-party contributions to our Primer projects,
including this one.

Note that this workflow triggers on merge queue entries, even though
the Probot app upon which it's based doesn't have explicit support for
that. However, it may not matter in practice, as presumably any PR
that enters the merge queue will have already passed the DCO check in
the first place.

For now, this check isn't a required job, only advisory, so it won't
block anything from merging, in any case.

Signed-off-by: Drew Hess <src@drewhess.com>
