### PR TITLE
fix: specify the version of `pnpm` to install with `npx`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,7 @@
                 export PATH="$(pwd)/node_modules/.bin:$PATH"
 
                 if ! type -P pnpm ; then
-                  npx pnpm add pnpm
+                  npx pnpm@8.5.1 add pnpm
                 else
                   pnpm install
                 fi


### PR DESCRIPTION
This fixes some weirdness we encountered with the recent upgrade of `pnpm` to `8.5.1`, where `npx` tried to install `7.x` and then the Nix shell bootstrap step failed.
