### PR TITLE
chore: the `pnpm` lockfile wasn't updated when we bumped to 8.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   trim@<0.0.3: '>=0.0.3'


### PR DESCRIPTION
Signed-off-by: Drew Hess <src@drewhess.com>
