### PR TITLE
chore: install `pnpm` from `nixpkgs`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,8 @@
           devShells.default = pkgs.mkShell {
             buildInputs = (with pkgs; [
               nixpkgs-fmt
-              nodejs-18_x
+              nodejs_18
+              nodejs_18.pkgs.pnpm
               rnix-lsp
             ]);
 
@@ -141,13 +142,7 @@
               in
               ''
                 export PATH="$(pwd)/node_modules/.bin:$PATH"
-
-                if ! type -P pnpm ; then
-                  npx pnpm@8.5.1 add pnpm
-                else
-                  pnpm install
-                fi
-
+                pnpm install
                 rm -f ${local-spec}
                 ln -s ${spec} ${local-spec}
                 pnpm generate

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "eslint-plugin-storybook": "^0.6.12",
     "eslint-plugin-tailwindcss": "^3.12.0",
     "orval": "^6.16.0",
-    "pnpm": "^8.5.1",
     "postcss": "^8.4.23",
     "postcss-import": "^15.1.0",
     "prettier": "^2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,9 +163,6 @@ devDependencies:
   orval:
     specifier: ^6.16.0
     version: 6.16.0(openapi-types@12.1.3)(typescript@4.9.5)
-  pnpm:
-    specifier: ^8.5.1
-    version: 8.5.1
   postcss:
     specifier: ^8.4.23
     version: 8.4.23
@@ -3677,7 +3674,7 @@ packages:
       open: 8.4.2
       picocolors: 1.0.0
       tiny-glob: 0.2.9
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: true
 
   /@rc-component/portal@1.1.1(react-dom@18.2.0)(react@18.2.0):
@@ -11601,12 +11598,6 @@ packages:
   /pluralize@7.0.0:
     resolution: {integrity: sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==}
     engines: {node: '>=4'}
-    dev: true
-
-  /pnpm@8.5.1:
-    resolution: {integrity: sha512-W6elL7Nww0a/MCICkzpkbxW6f99TQuX4DuJoDjWp39X08PKDkEpg4cgj3d6EtgYADcdQWl/eM8NdlLJVE3RgpA==}
-    engines: {node: '>=16.14'}
-    hasBin: true
     dev: true
 
   /polished@4.2.2:


### PR DESCRIPTION
Installing `pnpm` via `npx`, a dev dependency in `package.json`, and a
bootstrap step worked pretty well until our most recent upgrade (to
`pnpm` 8.5.1). Now we're running into a number of strange issues.

Let's just install `pnpm` from Nix. Contributors who aren't using Nix
can install a compatible `pnpm` version using whatever non-Nix
mechanism they prefer.

Note to current contributors: you will probably have to `rm -rf
node_modules` and then re-enter the Nix shell.

Signed-off-by: Drew Hess <src@drewhess.com>
