### PR TITLE
chore: add some more eslint ignore rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,6 @@ orval.config.ts
 src/primer-api/
 tailwind.config.js
 storybook-static/
+*.sqlite3
+*.sqlite3-journal
+*.md


### PR DESCRIPTION
I am sometimes seeing eslint errors complaining that it cannot parse primer.sqlite3{,-journal} and README.md. We now explicitly ignore these.