### PR TITLE
chore: tell `prettier` to ignore all `*.md` files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-README.md
+*.md
 .direnv/
 node_modules/
 dist/
@@ -13,5 +13,3 @@ primer-api.json
 src/primer-api/
 licenses/
 COPYING
-CODE_OF_CONDUCT.md
-SECURITY.md


### PR DESCRIPTION
Signed-off-by: Drew Hess <src@drewhess.com>
