### PR TITLE
feat: fit-to-view when changing the selected eval tree

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -529,6 +529,12 @@ const makePrimerNode = async (
   }
 };
 
+const FitView = (): JSX.Element => {
+  const { fitView } = useReactFlow();
+  fitView();
+  return <></>;
+};
+
 type PrimerNodeWithDefNoPos = PrimerNode<{ def: GlobalName }>;
 type PrimerNodeWithDef = Positioned<PrimerNodeWithDefNoPos>;
 
@@ -753,6 +759,7 @@ export const TreeReactFlowOne = (p: TreeReactFlowOneProps) => {
     >
       <Background gap={25} size={1.6} color="#81818a" />
       <ZoomBar />
+      <FitView />
     </ReactFlowSafe>
   );
 };


### PR DESCRIPTION
As implemented, this feature is buggy. The issue seems to be related
to how `fitView` calculates zoom levels. It's a bit hard to explain in
words, but briefly, the initially selected definition's tree is fitted
properly, but when you select a different definition, if you have
not *previously* selected that definition, then the zoom level doesn't
change: its eval tree will be rendered at the same zoom level as the
previously selected definition. However, on *subsequent* selections of
any definition, the zoom level *will* be set properly such that its
tree is properly fitted. There's also a visual glitch where the tree
is briefly rendered at the current zoom level before it snaps into the
correct zoom level.

(Note that I tried a different implementation of this feature, which
triggered a `fitView` callback whenever the definition being evaluated
is changed, but that didn't seem to work at all. It was also quite a
bit more convoluted than this implementation, as it used the `useRef`
technique we use in our scroll-to-def feature.)
