### PR TITLE
Demonstration of weird `fitView` behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,10 @@ import {
   useUndo,
   useRedo,
 } from "./primer-api";
-import { defaultTreeReactFlowProps } from "./components/TreeReactFlow";
+import {
+  defaultTreeReactFlowProps,
+  ScrollToDef,
+} from "@/components/TreeReactFlow";
 
 // hardcoded values (for now)
 const initialLevel: Level = "Expert";
@@ -200,6 +203,8 @@ const AppNoError = ({
   const canvasRef: RefObject<HTMLDivElement> = useRef(null);
   const canvasDimensions = useDimensions(canvasRef);
 
+  const scrollToDefRef = useRef<ScrollToDef | undefined>(undefined);
+
   return (
     <div className="grid h-screen grid-cols-[18rem_auto_20rem]">
       <div className="overflow-scroll">
@@ -221,7 +226,11 @@ const AppNoError = ({
               .sort((a, b) => cmpName(a, b))
               .map((t) => t.baseName),
           }}
-          onClickDef={(_label, _event) => ({})}
+          onClickDef={(defName, _event) => {
+            if (scrollToDefRef.current != undefined) {
+              scrollToDefRef.current(defName);
+            }
+          }}
           onClickAddDef={onClickAddDef}
           onClickTypeDef={(_label, _event) => ({})}
           onClickAddTypeDef={() => setShowCreateTypeDefModal(true)}
@@ -291,6 +300,7 @@ const AppNoError = ({
           )
         }
         <TreeReactFlow
+          scrollToDefRef={scrollToDefRef}
           {...defaultTreeReactFlowProps}
           {...(selection && { selection })}
           onNodeClick={(_e, node) => {

--- a/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
+++ b/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
@@ -1,8 +1,10 @@
+import { useRef } from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import {
   defaultTreeReactFlowProps,
   TreeReactFlow,
   TreeReactFlowProps,
+  ScrollToDef,
 } from "./";
 import {
   tree1,
@@ -88,17 +90,24 @@ export const Tree1: ComponentStory<typeof TreeReactFlow> = (
 ) =>
   treeSized({
     ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
     defs: [def1],
     selection: { def: def1.name, node: { nodeType: "BodyNode", id: 100 } },
   });
 export const Tree2: ComponentStory<typeof TreeReactFlow> = (
   args: TreeReactFlowProps
-) => treeSized({ ...args, defs: [def2] });
+) =>
+  treeSized({
+    ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
+    defs: [def2],
+  });
 export const Tree3: ComponentStory<typeof TreeReactFlow> = (
   args: TreeReactFlowProps
 ) =>
   treeSized({
     ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
     defs: [def3],
     selection: { def: def3.name, node: { nodeType: "BodyNode", id: 301 } },
   });
@@ -107,6 +116,7 @@ export const Tree4: ComponentStory<typeof TreeReactFlow> = (
 ) =>
   treeSized({
     ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
     defs: [def4],
     selection: { def: def4.name, node: { nodeType: "BodyNode", id: 409 } },
   });
@@ -115,6 +125,7 @@ export const Tree5: ComponentStory<typeof TreeReactFlow> = (
 ) =>
   treeSized({
     ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
     defs: [def5],
     selection: { def: def5.name, node: { nodeType: "BodyNode", id: 503 } },
   });
@@ -123,6 +134,7 @@ export const AllTrees: ComponentStory<typeof TreeReactFlow> = (
 ) =>
   treeSized({
     ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
     defs: [def1, def2, def3, def4, def5],
     selection: { def: def3.name, node: { nodeType: "BodyNode", id: 301 } },
   });
@@ -131,6 +143,7 @@ export const OddAndEven: ComponentStory<typeof TreeReactFlow> = (
 ) =>
   treeSized({
     ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
     defs: oddEvenDefs,
     selection: { def: def5.name, node: { nodeType: "BodyNode", id: 5 } },
   });
@@ -139,6 +152,7 @@ export const OddAndEvenMiscStyles: ComponentStory<typeof TreeReactFlow> = (
 ) =>
   treeSized({
     ...args,
+    scrollToDefRef: useRef<ScrollToDef | undefined>(undefined),
     defs: oddEvenDefsMiscStyles,
     selection: { def: def5.name, node: { nodeType: "BodyNode", id: 5 } },
   });

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -683,6 +683,7 @@ export const TreeReactFlow = (p: TreeReactFlowProps) => {
       <Background gap={25} size={1.6} color="#81818a" />
       <ZoomBar />
       <SetCallbacks scrollToDefRef={p.scrollToDefRef} />
+      <FitView />
     </ReactFlowSafe>
   );
 };
@@ -796,7 +797,6 @@ export const ReactFlowSafe = <
     <ReactFlow
       {...{
         ...p,
-        fitView: true,
         // Note: we should try to detect this based on the bounding
         // box of the canvas.
         minZoom: 0.001,

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -529,6 +529,12 @@ const makePrimerNode = async (
   }
 };
 
+const FitView = (): JSX.Element => {
+  const { fitView } = useReactFlow();
+  fitView();
+  return <></>;
+};
+
 type PrimerNodeWithDefNoPos = PrimerNode<{ def: GlobalName }>;
 type PrimerNodeWithDef = Positioned<PrimerNodeWithDefNoPos>;
 
@@ -753,6 +759,7 @@ export const TreeReactFlowOne = (p: TreeReactFlowOneProps) => {
     >
       <Background gap={25} size={1.6} color="#81818a" />
       <ZoomBar />
+      <FitView />
     </ReactFlowSafe>
   );
 };

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -20,9 +20,10 @@ import {
   EdgeProps,
   getBezierPath,
   EdgeTypes,
+  useReactFlow,
 } from "reactflow";
 import "./reactflow.css";
-import { useEffect, useId, useState } from "react";
+import { MutableRefObject, useEffect, useId, useState } from "react";
 import classNames from "classnames";
 import { unzip } from "fp-ts/lib/Array";
 import {
@@ -60,6 +61,8 @@ import {
 import { ZoomBar } from "./ZoomBar";
 import { WasmLayoutType } from "@zxch3n/tidy/wasm_dist";
 
+export type ScrollToDef = (defName: string) => void;
+
 /** These properties are needed to construct nodes, but are invariant across all nodes. */
 type NodeParams = {
   nodeWidth: number;
@@ -78,6 +81,7 @@ export type TreeReactFlowProps = {
   forestLayout: "Horizontal" | "Vertical";
   defNameNodeSizeMultipliers: { width: number; height: number };
   layout: LayoutParams;
+  scrollToDefRef: MutableRefObject<ScrollToDef | undefined>;
 } & NodeParams;
 export const defaultTreeReactFlowProps: Pick<
   TreeReactFlowProps,
@@ -99,6 +103,10 @@ export const defaultTreeReactFlowProps: Pick<
     margins: { child: 25, sibling: 18 },
   },
 };
+
+// This should probably take a `GlobalName` instead, but we're not
+// quite there yet.
+const defNameToNodeId = (name: string) => `def-${name}`;
 
 const handle = (type: HandleType, position: Position) => (
   <Handle id={position} isConnectable={false} type={type} position={position} />
@@ -550,7 +558,7 @@ export const TreeReactFlow = (p: TreeReactFlowProps) => {
             ]
           >
         >(async (def) => {
-          const defNodeId = "def-" + def.name.baseName;
+          const defNodeId = defNameToNodeId(def.name.baseName);
           const sigEdgeId = "def-sig-" + def.name.baseName;
           const bodyEdgeId = "def-body-" + def.name.baseName;
           const defNameNode: PrimerNode = {
@@ -668,8 +676,32 @@ export const TreeReactFlow = (p: TreeReactFlowProps) => {
     >
       <Background gap={25} size={1.6} color="#81818a" />
       <ZoomBar />
+      <SetCallbacks scrollToDefRef={p.scrollToDefRef} />
     </ReactFlowSafe>
   );
+};
+
+// This component is rendered purely for side effects. We do this
+// rather than wrap our `ReactFlow` components with
+// `ReactFlowProvider`s.
+export const SetCallbacks = ({
+  scrollToDefRef,
+}: {
+  scrollToDefRef: MutableRefObject<ScrollToDef | undefined>;
+}) => {
+  const { fitView, getZoom } = useReactFlow();
+  const scrollToDef: ScrollToDef = (defName: string) => {
+    // Don't change the current zoom level when scrolling to a
+    // definition.
+    const zoomLevel: number = getZoom();
+    fitView({
+      nodes: [{ id: defNameToNodeId(defName) }],
+      minZoom: zoomLevel,
+      maxZoom: zoomLevel,
+    });
+  };
+  scrollToDefRef.current = scrollToDef;
+  return <></>;
 };
 
 export default TreeReactFlow;


### PR DESCRIPTION
This PR is not intended for review or merging, but only to demonstrate some odd behavior. The 3rd commit in this PR is something I tried to work around the flakiness of #929: remove the `fitView: true`  property on our `<ReactFlow>` trees, which is supposed to fit exactly once, upon initial rendering, and replace it with the `<FitView />` pseudo-component I developed for #929.

What you'll notice in this PR is that when you select a definition to evaluate in the live eval window, not only is that tree fitted to its view, but *so is the main canvas*. Here's a video to demonstrate:

https://github.com/hackworthltd/primer-app/assets/2438/f39ef7b7-0f64-454b-bb98-04f7a7d0993d

So I suspect we will need `<ReactFlowProvider>`, after all, to properly manage our 2 instances of `<ReactFlow>` trees. That said, when I tried inserting `<ReactFlowProvider>` in the obvious places, it didn't fix the issue demonstrated by this PR, so there seems to be something deeper going on.