### PR TITLE
feat: pan the canvas regardless of what's underneath the pointer

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -794,6 +794,10 @@ export const ReactFlowSafe = <
         // box of the canvas.
         minZoom: 0.001,
         edgeTypes,
+        nodesDraggable: false,
+        // Note that despite the name, we can still select nodes in
+        // the tree in order to perform actions on them.
+        elementsSelectable: false,
         onNodeClick: (e, n) => {
           "onNodeClick" in p &&
             p.onNodeClick(


### PR DESCRIPTION
Prior to this change, panning could be quite frustrating, because if the cursor was placed over a node or an edge of a `ReactFlow`, the flow didn't propagate the pan/drag event to the underlying canvas. Now it works everywhere on the canvas, regardless of what's underneath the cursor.
