### PR TITLE
chore: factor out a generic action panel button type

### DIFF
--- a/src/Actions.tsx
+++ b/src/Actions.tsx
@@ -1,15 +1,14 @@
-import { InputAction, NoInputAction, Level } from "./primer-api";
+import { InputAction, NoInputAction, Level } from "@/primer-api";
+import type { Name } from "@/components/ActionPanelButton";
 
 export type ActionType = "Primary" | "Destructive";
 
-export const actionName = (
-  action: NoInputAction | InputAction
-): { font?: string; text: string } => {
-  const code = (text: string) => {
-    return { font: "font-code", text };
+export const actionName = (action: NoInputAction | InputAction): Name => {
+  const code = (text: string): Name => {
+    return { text: text, style: "code" };
   };
-  const prose = (text: string) => {
-    return { text };
+  const prose = (text: string): Name => {
+    return { text: text, style: "prose" };
   };
   switch (action) {
     case "MakeCase":

--- a/src/components/ActionButton/index.tsx
+++ b/src/components/ActionButton/index.tsx
@@ -1,6 +1,7 @@
 import "@/index.css";
 
 import classNames from "classnames";
+
 import { Action, Level } from "@/primer-api";
 import {
   actionDescription,
@@ -8,6 +9,19 @@ import {
   actionType,
   ActionType,
 } from "@/Actions";
+import { ActionPanelButton, Appearance } from "@/components/ActionPanelButton";
+
+// We will want other types of buttons styled roughly the same way
+// We export all the styling combined except the width and padding
+export const buttonClassesBase =
+  "inline-flex items-center text-base rounded border font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2";
+const buttonClassesPrimaryExtra =
+  "border-grey-primary text-blue-primary bg-white-primary hover:bg-blue-primary hover:text-white-primary focus:ring-blue-primary";
+export const buttonClassesPrimary = classNames(
+  buttonClassesBase,
+  buttonClassesPrimaryExtra
+);
+export const buttonClassesPad = "px-3 py-6";
 
 export type ActionButtonProps = {
   level: Level;
@@ -15,52 +29,23 @@ export type ActionButtonProps = {
   onClick: (event: React.MouseEvent, action: Action) => void;
 };
 
-// We will want other types of buttons styled roughly the same way
-// We export all the styling combined except the width and padding
-export const buttonClassesBase =
-  "inline-flex items-center text-base rounded border font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2";
-const buttonClassesWidth = "w-full";
-const buttonClassesPrimaryExtra =
-  "border-grey-primary text-blue-primary bg-white-primary hover:bg-blue-primary hover:text-white-primary focus:ring-blue-primary";
-const buttonClassesSecondaryExtra =
-  "border-red-secondary text-white-primary bg-red-secondary hover:bg-red-secondary-hover hover:border-red-secondary-hover focus:ring-red-primary";
-export const buttonClassesPrimary = classNames(
-  buttonClassesBase,
-  buttonClassesPrimaryExtra
-);
-export const buttonClassesSecondary = classNames(
-  buttonClassesBase,
-  buttonClassesSecondaryExtra
-);
-export const buttonClassesPad = "px-3 py-6";
-
-const buttonClasses = (appearance: ActionType) =>
-  classNames({
-    [buttonClassesPrimaryExtra]: appearance === "Primary",
-    [buttonClassesSecondaryExtra]: appearance === "Destructive",
-    [buttonClassesBase]: true,
-    [buttonClassesWidth]: true,
-    [buttonClassesPad]: true,
-  });
+const appearance = (actionType: ActionType): Appearance => {
+  switch (actionType) {
+    case "Primary":
+      return "primary";
+    case "Destructive":
+      return "danger";
+  }
+};
 
 export const ActionButton = (p: ActionButtonProps): JSX.Element => {
-  const name = actionName(p.action.contents);
   return (
-    <button
-      type="button"
-      className={buttonClasses(actionType(p.action.contents))}
+    <ActionPanelButton
+      appearance={appearance(actionType(p.action.contents))}
+      name={actionName(p.action.contents)}
+      description={actionDescription(p.action.contents, p.level)}
       onClick={(e) => p.onClick(e, p.action)}
-    >
-      <div
-        className={classNames("mr-4 w-8 flex-none", name.font)}
-        aria-hidden="true"
-      >
-        {name.text}
-      </div>
-      <p className="text-left">
-        {actionDescription(p.action.contents, p.level)}
-      </p>
-    </button>
+    />
   );
 };
 

--- a/src/components/ActionPanel/index.tsx
+++ b/src/components/ActionPanel/index.tsx
@@ -1,6 +1,6 @@
 import "@/index.css";
 
-import { ActionButton } from "@/components";
+import { ActionButton, ActionPanelButton } from "@/components";
 import {
   Action,
   Level,
@@ -13,8 +13,6 @@ import { actionType } from "@/Actions";
 import { partition } from "fp-ts/lib/Array";
 import { useState } from "react";
 import { ActionInput } from "../ActionInput";
-import { buttonClassesPrimary, buttonClassesSecondary } from "../ActionButton";
-import classNames from "classnames";
 
 export interface ActionPanelProps {
   actions: Action[];
@@ -91,29 +89,23 @@ export const ActionPanel = ({
                   )}
                   <ul>
                     {state.opts.opts.map((option) => (
-                      <li key={JSON.stringify(option)}>
-                        <button
-                          className={classNames(
-                            buttonClassesPrimary,
-                            "w-full p-2 mt-2"
-                          )}
+                      <li key={JSON.stringify(option)} className="pt-2">
+                        <ActionPanelButton
+                          appearance="primary"
                           onClick={(_) => onOption(option)}
-                        >
-                          {option.option}
-                        </button>
+                          name={{ text: option.option, style: "code" }}
+                        />
                       </li>
                     ))}
                   </ul>
+                  <div className="pt-2">
+                    <ActionPanelButton
+                      appearance="danger"
+                      onClick={(_) => setState({ state: "ActionList" })}
+                      description="Cancel"
+                    />
+                  </div>
                 </div>
-                <button
-                  className={classNames(
-                    buttonClassesSecondary,
-                    "w-full justify-center p-3 pt-2 mt-8"
-                  )}
-                  onClick={(_) => setState({ state: "ActionList" })}
-                >
-                  Cancel
-                </button>
               </div>
             );
           }

--- a/src/components/ActionPanelButton/ActionPanelButton.stories.tsx
+++ b/src/components/ActionPanelButton/ActionPanelButton.stories.tsx
@@ -1,0 +1,87 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import type { ActionPanelButtonProps, Appearance } from "./";
+import { ActionPanelButton } from "./";
+
+const appearances: Array<Appearance> = ["primary", "danger"];
+
+export default {
+  title: "Application/Component Library/Buttons/ActionPanelButton",
+  component: ActionPanelButton,
+  argTypes: {
+    appearance: {
+      description: "Pre-defined appearances.",
+      options: appearances,
+      control: { type: "radio" },
+    },
+    name: {
+      description: "Button short name and style.",
+      control: "object",
+    },
+    description: {
+      description: "The button's description.",
+      control: "text",
+    },
+    onClick: {
+      description: "The onClick handler.",
+      action: "clicked",
+    },
+  },
+} as ComponentMeta<typeof ActionPanelButton>;
+
+const Template: ComponentStory<typeof ActionPanelButton> = (
+  args: ActionPanelButtonProps
+) => (
+  <>
+    <div className="w-96">
+      <ActionPanelButton {...args} />
+    </div>
+  </>
+);
+
+export const Single = Template.bind({});
+Single.args = {
+  appearance: "primary",
+  name: { text: "x", style: "code" },
+  description: "Use a variable",
+};
+
+const AllButtonsTemplate: ComponentStory<typeof ActionPanelButton> = (args) => (
+  <>
+    <h1 className="text-xl">Primary with name as code</h1>
+    <div className="mb-8 mt-4 w-96">
+      <ActionPanelButton
+        {...args}
+        appearance="primary"
+        name={{ text: "x", style: "code" }}
+        description="Use a variable"
+      />
+    </div>
+
+    <h1 className="text-xl">Primary with no name</h1>
+    <div className="mb-8 mt-4 w-96">
+      <ActionPanelButton
+        {...args}
+        appearance="primary"
+        description="Use a variable"
+      />
+    </div>
+
+    <h1 className="text-xl">Danger with name as prose</h1>
+    <div className="mb-8 mt-4 w-96">
+      <ActionPanelButton
+        {...args}
+        appearance="danger"
+        name={{ text: "⌫", style: "prose" }}
+        description="Delete everything"
+      />
+    </div>
+
+    <h1 className="text-xl">Danger with no name</h1>
+    <div className="mb-8 mt-4 w-96">
+      <ActionPanelButton {...args} appearance="danger" description="Cancel" />
+    </div>
+  </>
+);
+
+export const Showcase = AllButtonsTemplate.bind({});

--- a/src/components/ActionPanelButton/index.tsx
+++ b/src/components/ActionPanelButton/index.tsx
@@ -1,0 +1,70 @@
+import type { MouseEventHandler } from "react";
+
+import "@/index.css";
+
+import classNames from "classnames";
+
+export type Appearance = "primary" | "danger";
+export type NameStyle = "code" | "prose";
+export type Name = {
+  text: string;
+  style: NameStyle;
+};
+
+export type ActionPanelButtonProps = {
+  appearance: Appearance;
+  name?: Name;
+  description?: string;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+};
+
+type Height = "tall" | "short";
+
+const buttonClasses = (appearance: Appearance, height: Height) =>
+  classNames({
+    "inline-flex items-center w-full px-3 text-base rounded border font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2":
+      true,
+    "py-6": height === "tall",
+    "py-3": height === "short",
+    "border-grey-primary text-blue-primary bg-white-primary hover:bg-blue-primary hover:text-white-primary focus:ring-blue-primary":
+      appearance === "primary",
+    "border-red-secondary text-white-primary bg-red-secondary hover:bg-red-secondary-hover hover:border-red-secondary-hover focus:ring-red-primary":
+      appearance === "danger",
+  });
+
+export const ActionPanelButton = (p: ActionPanelButtonProps): JSX.Element => {
+  return (
+    <button
+      type="button"
+      className={buttonClasses(
+        p.appearance,
+        p.name && p.description ? "tall" : "short"
+      )}
+      onClick={p.onClick}
+    >
+      {p.name ? (
+        <>
+          <div
+            className={classNames(
+              "mr-4 w-8 flex-none",
+              p.name.style === "code" ? "font-code" : "",
+              p.description ? "text-left" : "grow text-center"
+            )}
+            aria-hidden="true"
+          >
+            {p.name.text}
+          </div>
+          {p.description && <p className="text-left">{p.description}</p>}
+        </>
+      ) : (
+        p.description && (
+          <div className="grow">
+            <p className="text-center">{p.description}</p>
+          </div>
+        )
+      )}
+    </button>
+  );
+};
+
+export default ActionPanelButton;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as ActionButton } from "./ActionButton";
+export { default as ActionPanelButton } from "./ActionPanelButton";
 export { default as ActionPanel } from "./ActionPanel";
 export { default as Avatar } from "./Avatar";
 export { default as BinaryTreePlaceholder } from "./BinaryTreePlaceholder";


### PR DESCRIPTION
Among the changes here are:

* All buttons in the action panel now have consistent styling
* Buttons without either a description or a "name" (i.e., short label) are short, buttons with both are tall.
* Format offered variables (names) as code
* When only a name appears on a button, center it. This means the list of offered variables will now be centered, rather than right-ragged.
