### PR TITLE
chore: replace deprecated Dicebear avatar packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@dicebear/avatars": "^4.10.8",
-    "@dicebear/avatars-bottts-sprites": "^4.10.8",
-    "@dicebear/avatars-identicon-sprites": "^4.10.8",
-    "@dicebear/avatars-jdenticon-sprites": "^4.10.8",
+    "@dicebear/collection": "^6.0.4",
+    "@dicebear/core": "^6.0.4",
     "@hookform/resolvers": "^3.1.0",
     "@neodrag/react": "^2.0.3",
     "@tanstack/react-query": "^4.29.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,12 @@ overrides:
   '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1
 
 dependencies:
-  '@dicebear/avatars':
-    specifier: ^4.10.8
-    version: 4.10.8
-  '@dicebear/avatars-bottts-sprites':
-    specifier: ^4.10.8
-    version: 4.10.8(@dicebear/avatars@4.10.8)
-  '@dicebear/avatars-identicon-sprites':
-    specifier: ^4.10.8
-    version: 4.10.8(@dicebear/avatars@4.10.8)
-  '@dicebear/avatars-jdenticon-sprites':
-    specifier: ^4.10.8
-    version: 4.10.8(@dicebear/avatars@4.10.8)
+  '@dicebear/collection':
+    specifier: ^6.0.4
+    version: 6.0.4(@dicebear/core@6.0.4)
+  '@dicebear/core':
+    specifier: ^6.0.4
+    version: 6.0.4
   '@hookform/resolvers':
     specifier: ^3.1.0
     version: 3.1.0(react-hook-form@7.44.1)
@@ -2722,41 +2716,314 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /@dicebear/avatars-bottts-sprites@4.10.8(@dicebear/avatars@4.10.8):
-    resolution: {integrity: sha512-XwZkfDO6qyKEyHeU9Skk6lodteIzFm/wP3qUyve9nQx8Q1Y3tz39apfI6uHe9rsJcGSgehNlcWi/QIhb0atvmg==}
-    deprecated: 'This package is deprecated. Use ''@dicebear/bottts'' instead. Read more: https://dicebear.com/styles/bottts'
+  /@dicebear/adventurer-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-qRYk8potvJufC6x4WIA2fnSG8hxJpSXk3KDbrcXhHZGcDH8I+VogoBLqoJbotSgCkTMmzek5uguJ8tTsOmWPAg==}
+    engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@dicebear/avatars': ^4.6.0
+      '@dicebear/core': ^6.0.0
     dependencies:
-      '@dicebear/avatars': 4.10.8
+      '@dicebear/core': 6.0.4
     dev: false
 
-  /@dicebear/avatars-identicon-sprites@4.10.8(@dicebear/avatars@4.10.8):
-    resolution: {integrity: sha512-eUeD0X6AYB49PY6mlh12SPEEozlrLKsZx+MQv+Dvwz8V4uZH1LV1O9tiXegmd+MskruICUGvSk30x0tmoR2aZA==}
-    deprecated: 'This package is deprecated. Use ''@dicebear/identicon'' instead. Read more: https://dicebear.com/styles/identicon'
+  /@dicebear/adventurer@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-mQEpdEeAd/pldLWgETlke+blMdBuPZRrsSStYDf/Ve/67WFUOiPCYyOzCz1TDrpvDrcq85EV9uqc8jGfTnywRw==}
+    engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@dicebear/avatars': ^4.6.0
+      '@dicebear/core': ^6.0.0
     dependencies:
-      '@dicebear/avatars': 4.10.8
+      '@dicebear/core': 6.0.4
     dev: false
 
-  /@dicebear/avatars-jdenticon-sprites@4.10.8(@dicebear/avatars@4.10.8):
-    resolution: {integrity: sha512-bjaJo+vtEbLYItjUe6RFjzelT199UNIzYCkLaq1ybUKOWZNWLocFPhvKWxzAqLH0JDn8VO5QJN+Kv5ul9ALHzA==}
-    deprecated: 'This package is deprecated. Read more: https://github.com/dicebear/dicebear/discussions/187'
+  /@dicebear/avataaars-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-aF+bRvr2lHMEuzmewW2rZYRb05ipSh0q0O7bJDPPjdIU/RdyY5no/xuka1kssA2xH5NSAi/ruIOtNctYY8315g==}
+    engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@dicebear/avatars': ^4.6.0
+      '@dicebear/core': ^6.0.0
     dependencies:
-      '@dicebear/avatars': 4.10.8
-      jdenticon: 2.2.0
+      '@dicebear/core': 6.0.4
     dev: false
 
-  /@dicebear/avatars@4.10.8:
-    resolution: {integrity: sha512-jni3+W1yRRh4sJYmuQUZ8JpKI9aEEud53TUcxNFtntdRyOUJygIFdC5JPKNac58eALnBTZZ4ox7b+oeo0Ux/oA==}
-    deprecated: 'This package is deprecated. Use ''@dicebear/core'' instead. Read more: https://dicebear.com/how-to-use/js-library'
+  /@dicebear/avataaars@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-NEAiRykguMf4gTI9P8Uc5Mvthrr6gHmGyRPcd1UI6ndZs8ShgS5JqkaHeBEm88AmPDUvtibemSBkQ4pbH/ibbg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/big-ears-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-H6+4Wd1Jp7RhrbQQaAGdmXGsXIh9XGFOMxULT2yiAAkOCWCk6iNCbbNfLD8xBUYOg2tZFLhpG3tUVdVs99ttaQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/big-ears@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-/UspTsmClXodKGLZHGXaTHtLUVyjjiMPZip16BG8SkbAEkgEhV+ptCBV5ky2aOLjEYSYO2wCWs6Jkvsk5ONzaQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/big-smile@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-u7h/aSHPD2T6H4//Qqko0DeFjq+nfEXyW44V2S4VNs03UZ1VOENZWCknjvK5UY3/RxLVepU9BGQ2rz5huJkbCw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/bottts-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-I3cvxJjqX1y+DgS61gqegzdPmvXATRCvGyXfourxBi8z9C20rlotvHryHKaA/SW/ZH7C8AHrD2gvEW+i3vGVlw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/bottts@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-dfIPCVaIgiyTSpxSBZnjSahjl9EqYD1/8K3N2aQoUjIN2zb9F63xkzVfeJyF3Yq3K9T0qHiUZbdjFqUxbkDeYQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/collection@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-HpT6I1VlPgB8qoEvRZptZR59AzXzUMhKI678XHG73RAZ2nUWO87tHgUzv4Ieaj4XxUTHpf47crUAGIT1DEbpiw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/adventurer': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/adventurer-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/avataaars': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/avataaars-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/big-ears': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/big-ears-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/big-smile': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/bottts': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/bottts-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/core': 6.0.4
+      '@dicebear/croodles': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/croodles-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/fun-emoji': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/icons': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/identicon': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/initials': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/lorelei': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/lorelei-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/micah': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/miniavs': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/notionists': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/notionists-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/open-peeps': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/personas': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/pixel-art': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/pixel-art-neutral': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/shapes': 6.0.4(@dicebear/core@6.0.4)
+      '@dicebear/thumbs': 6.0.4(@dicebear/core@6.0.4)
+    dev: false
+
+  /@dicebear/converter@6.0.4:
+    resolution: {integrity: sha512-Zmf2f3Hk+LPclV7+zYb2FZ+U59irS+mzPK9/cHzkKKMxrmzEKBSWNrume1iRcuVb3X/oSEJa70sA8Cu/9PE12A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@resvg/resvg-js': ^2.4.1
+      exiftool-vendored: ^21.2.0
+      sharp: ^0.32.1
+    peerDependenciesMeta:
+      '@resvg/resvg-js':
+        optional: true
+      exiftool-vendored:
+        optional: true
+      sharp:
+        optional: true
     dependencies:
       '@types/json-schema': 7.0.12
-      pure-color: 1.3.0
-      svgson: 5.2.1
+      tmp-promise: 3.0.3
+    dev: false
+
+  /@dicebear/core@6.0.4:
+    resolution: {integrity: sha512-N+zP0g8r4CegXnqtJ5c8YH1NUZCH2C9ojEmtuo+9wqHvm0jAfsOfw777ydN7tV4GKw/xAGUvM6XagthX0EhDIQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@dicebear/converter': 6.0.4
+      '@types/json-schema': 7.0.12
+    transitivePeerDependencies:
+      - '@resvg/resvg-js'
+      - exiftool-vendored
+      - sharp
+    dev: false
+
+  /@dicebear/croodles-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-Ky+skOcqT3wIwvfyDCLqzs5xQLI1ISbSByTBLoSamQMNtCYAfy4dkqhxTGF/IiWFDys7b5JLQrwF6Fojlt4zlQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/croodles@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-N5nJzFYhtdSASy1rPhXTl0zP2KrrvX4KEcLp1jSdRPN/OCxv9HxWqREWVsdG6rOfJtG6D5NswClO18qqUk+sSg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/fun-emoji@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-6hoMFa5IwylMwAGNQd6VqOm2aJ+k+Ovfg76EW3bUNe436YYILjymwgjWpJdvCevju2oSMUxXfsMZ0s7tLsR7lQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/icons@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-1gSiui6bUxFIHAgCYn6ZiajKjEa9qdvv0cXhHFdl/e5mgA6whZnzRCvM1zYthw3t4BAAcfU3WoTdgyQ1Kg3R6w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/identicon@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-h/ffctx/4tGRhzMFiGA47TWObWVFtExDbgIEgUlGmh26Xp72Fl3uXSrS8T5C6bg9Qv6F+kTnkUy1BNVvaR/kbQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/initials@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-TJfGkhKCLkDrUAifXMCn/rhTu95lKQcYoJbCZuQd15oF+Re8fGKjFDXOY/oUjmrWHaGSMU2sW0VoHGnTAWHpUg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/lorelei-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-YCkW9lJxMiI0YZUsqze1cWhxYeZPrn81AQkJm4yl4MsLy+BORRAfpkJX9cTA5bzsTZRd+yjLhPyPJQMBfth6Xw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/lorelei@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-ExAju4tkkH1T7ghRHgFch+gRPDTTDjXyRseYuZzXjHVT/ro9I5ZTQRw1dWfoRyw4kh4fvPJG3mwo1lO4Ibr3LA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/micah@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-sIFyfJ3KX1WalmePoyYvuF6lr+wcrVfaO+d3ElRJIUmqpn3ZKZ1I5616JvwiSdLMbxyCRS1gwo6yjqcYNo3XcQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/miniavs@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-qwu8ZuAMwvOesaX1VS7uWbq0ghIPkybeu0gS/JXuEbYoMxn3/nUo/jgj79mYdTQseW8psPcTS3vi+k8J+Ds2/g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/notionists-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-nYkWD6nQxwV85IID/OTFBjE+nIRSSQdUS2ng+qxSxb3RIoZBONnE5t74lsZNuG4qNvsp0eP4NMOdiISOSWs4YA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/notionists@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-3z34zHfCdHawf4lqR6C+5Xqf2XrQ9kn8hVNG/2Ns4I65mEs6pdacQi3nyk9/P8554QZcqMOq54vAlCJnRoxyBw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/open-peeps@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-2vnQlI7vxqtXuu6j0k8gQPGA0nFQXWfji2KRkfSYjtErPlcNAb6++TD5eLX1vw+p/8Bl0U/pKRRoDoqavdQR1w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/personas@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-j2nyBORDx48f4XvkBuwKPx4fzAPAG6YQFkpL8O1DHxIaSh0U0nlBKwwb4XC8la83GzUlUF2QfW2a6j0rfKfweQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/pixel-art-neutral@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-ZDTP7vmXVgfr+vIbXQVlgNwRF9F1Bnj1ylckPtNVWjp/CKgRouLlOMuL2H+mmzsB1WS0r3AJKexQ1swaccDK8w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/pixel-art@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-UAH+1SxzOGMLM/3lOmNcI7dotlGoOQGDPbUhHux1weaJbnOzJLMAUYTpnEW9JoPpk5IclrpR/YH5W6VUcPchXw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/shapes@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-fDp/AZUR0oIx9TnRFNw+MSIvP6baudaivpUxflLenCabKLHhMHREDrHJuXUOBe2OCfx1HR7PQlYUOUuXDBCBCQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
+    dev: false
+
+  /@dicebear/thumbs@6.0.4(@dicebear/core@6.0.4):
+    resolution: {integrity: sha512-0W+QbDCpEtuVQed/Hj1BICm/RJSd4RU5ZjtulITDHozjVyej0c4sRx3iLZ23gz/YxxTu1xzA6C+OT3yPQ1db5Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^6.0.0
+    dependencies:
+      '@dicebear/core': 6.0.4
     dev: false
 
   /@discoveryjs/json-ext@0.5.7:
@@ -5659,10 +5926,6 @@ packages:
     resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
     dev: false
 
-  /@types/json-schema@7.0.11:
-    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
-    dev: true
-
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
 
@@ -5725,6 +5988,7 @@ packages:
 
   /@types/node@20.2.5:
     resolution: {integrity: sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==}
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -5969,7 +6233,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
@@ -6855,7 +7119,6 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -6937,7 +7200,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
 
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -7083,10 +7345,6 @@ packages:
   /caniuse-lite@1.0.30001477:
     resolution: {integrity: sha512-lZim4iUHhGcy5p+Ri/G7m84hJwncj+Kz7S5aD4hoQfslKZJgt0tHc/hafVbqHC5bbhHb+mrW2JOUHkI5KH7toQ==}
     dev: true
-
-  /canvas-renderer@2.1.1:
-    resolution: {integrity: sha512-/V0XetN7s1Mk3NO7x2wxPZYv0pLMQtGAhecuOuKR88beiYCUle1AbCcFZNLu+4NVzi9RVHS0rXtIgzPEaKidLw==}
-    dev: false
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -7352,7 +7610,6 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
-    dev: true
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -7642,14 +7899,6 @@ packages:
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
-
-  /deep-rename-keys@0.2.1:
-    resolution: {integrity: sha512-RHd9ABw4Fvk+gYDWqwOftG849x0bYOySl/RgX0tLI9i27ZIeSO91mLZJEp7oPHOMFqHvpgu21YptmDt0FYD/0A==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: 3.2.2
-      rename-keys: 1.2.0
-    dev: false
 
   /deepmerge@2.2.1:
     resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
@@ -8731,10 +8980,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /eventemitter3@2.0.3:
-    resolution: {integrity: sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==}
-    dev: false
-
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -9110,7 +9355,6 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-    dev: true
 
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -9252,11 +9496,6 @@ packages:
       - supports-color
     dev: true
 
-  /get-value@2.0.6:
-    resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /giget@1.1.2:
     resolution: {integrity: sha512-HsLoS07HiQ5oqvObOI+Qb2tyZH4Gj5nYGfF9qQcZNrPw+uEFhdXtgJr01aO2pWadGHucajYDLxxbtQkm97ON2A==}
     hasBin: true
@@ -9334,7 +9573,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /glob@8.0.3:
     resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
@@ -9503,20 +9741,6 @@ packages:
   /has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
     dev: true
-
-  /has-value@0.3.1:
-    resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      get-value: 2.0.6
-      has-values: 0.1.4
-      isobject: 2.1.0
-    dev: false
-
-  /has-values@0.1.4:
-    resolution: {integrity: sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -9715,11 +9939,9 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: true
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /ini@3.0.1:
     resolution: {integrity: sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==}
@@ -9817,10 +10039,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
-
-  /is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-    dev: false
 
   /is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
@@ -9945,6 +10163,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
+    dev: true
 
   /is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -10039,6 +10258,7 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: true
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -10048,16 +10268,10 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /isobject@2.1.0:
-    resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isarray: 1.0.0
-    dev: false
-
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /isomorphic-unfetch@3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
@@ -10113,14 +10327,6 @@ packages:
       filelist: 1.0.4
       minimatch: 3.1.2
     dev: true
-
-  /jdenticon@2.2.0:
-    resolution: {integrity: sha512-WGqwpjN9pab/Sah9pGnFH5tQc3HF3WbLV/tPVbykvk5nuAkxG/zhzQYWC2owvpnS+/A0HmlSx35rtY8kyN+x7Q==}
-    hasBin: true
-    dependencies:
-      '@types/node': 20.2.5
-      canvas-renderer: 2.1.1
-    dev: false
 
   /jest-haste-map@29.5.0:
     resolution: {integrity: sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==}
@@ -10413,13 +10619,6 @@ packages:
     dependencies:
       json-buffer: 3.0.1
     dev: true
-
-  /kind-of@3.2.2:
-    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-buffer: 1.1.6
-    dev: false
 
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -10838,7 +11037,6 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -11211,14 +11409,6 @@ packages:
       es-abstract: 1.21.1
     dev: true
 
-  /omit-deep@0.3.0:
-    resolution: {integrity: sha1-IcivNJm8rdKWUaIyy8rLxSRF6+w=}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-plain-object: 2.0.4
-      unset-value: 0.1.2
-    dev: false
-
   /on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -11241,7 +11431,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -11514,7 +11703,6 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -11850,10 +12038,6 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
-
-  /pure-color@1.3.0:
-    resolution: {integrity: sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==}
-    dev: false
 
   /qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
@@ -12795,11 +12979,6 @@ packages:
       unist-util-visit: 2.0.3
     dev: true
 
-  /rename-keys@1.2.0:
-    resolution: {integrity: sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg==}
-    engines: {node: '>= 0.8.0'}
-    dev: false
-
   /request-light@0.4.0:
     resolution: {integrity: sha512-fimzjIVw506FBZLspTAXHdpvgvQebyjpNyLRd0e6drPPRq7gcrROeGWRyF81wLqFg5ijPgnOQbmfck5wdTqpSA==}
     dependencies:
@@ -12929,7 +13108,6 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
-    dev: true
 
   /rollup@2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
@@ -13013,7 +13191,7 @@ packages:
     resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==}
     engines: {node: '>= 12.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
@@ -13602,14 +13780,6 @@ packages:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
     dev: true
 
-  /svgson@5.2.1:
-    resolution: {integrity: sha512-nbM6QuyZiKzQ0Uo51VDta93YJAr96ikyT40PsgJRrzynOGsOlnmJ6zAK5hUFyE5gnxcg7yuOPUWbUlmV9K0+Dg==}
-    dependencies:
-      deep-rename-keys: 0.2.1
-      omit-deep: 0.3.0
-      xml-reader: 2.4.3
-    dev: false
-
   /swagger2openapi@7.0.8:
     resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
     hasBin: true
@@ -13823,6 +13993,19 @@ packages:
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
     dev: true
+
+  /tmp-promise@3.0.3:
+    resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
+    dependencies:
+      tmp: 0.2.1
+    dev: false
+
+  /tmp@0.2.1:
+    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
+    engines: {node: '>=8.17.0'}
+    dependencies:
+      rimraf: 3.0.2
+    dev: false
 
   /tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -14224,14 +14407,6 @@ packages:
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.6
     dev: true
-
-  /unset-value@0.1.2:
-    resolution: {integrity: sha512-yhv5I4TsldLdE3UcVQn0hD2T5sNCPv4+qm/CTUpRKIpwthYRIipsAPdsrNpOI79hPQa0rTTeW22Fq6JWRcTgNg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      has-value: 0.3.1
-      isobject: 3.0.1
-    dev: false
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -14896,7 +15071,6 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /write-file-atomic@2.4.3:
     resolution: {integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==}
@@ -14940,19 +15114,6 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
-
-  /xml-lexer@0.2.2:
-    resolution: {integrity: sha512-G0i98epIwiUEiKmMcavmVdhtymW+pCAohMRgybyIME9ygfVu8QheIi+YoQh3ngiThsT0SQzJT4R0sKDEv8Ou0w==}
-    dependencies:
-      eventemitter3: 2.0.3
-    dev: false
-
-  /xml-reader@2.4.3:
-    resolution: {integrity: sha1-n4EMr3xCWlqvuEixxFEDyecddTA=}
-    dependencies:
-      eventemitter3: 2.0.3
-      xml-lexer: 0.2.2
-    dev: false
 
   /xregexp@2.0.0:
     resolution: {integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,5 +1,5 @@
 // Abstract avatar styles.
-export type AvatarStyle = "bottts" | "identicon" | "jdenticon";
+export type AvatarStyle = "bottts" | "identicon";
 
 // Placeholder account type.
 export interface Account {

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -22,7 +22,7 @@ const imgSrcs: (string | undefined)[] = [
 ];
 
 const allDecorations: Decoration[] = ["plain", "alert"];
-const allStyles: AvatarStyle[] = ["identicon", "jdenticon", "bottts"];
+const allStyles: AvatarStyle[] = ["identicon", "bottts"];
 const allSizes: Size[] = ["responsive", "sm", "md", "lg", "xl", "2xl"];
 const fixedSizes: Size[] = ["sm", "md", "lg", "xl", "2xl"];
 
@@ -95,20 +95,6 @@ const AllButtonsTemplate: ComponentStory<typeof Avatar> = () => (
       ))}
     </div>
 
-    <h1 className="text-xl">Jdenticon</h1>
-    <div className="mb-8 flex flex-row items-center justify-around">
-      {zipSizeIDs.map(([sz, id]) => (
-        <Avatar
-          id={id}
-          style="jdenticon"
-          imgSrc={undefined}
-          decoration="plain"
-          size={sz}
-          key={sz}
-        />
-      ))}
-    </div>
-
     <h1 className="text-xl">Bottts</h1>
     <div className="mb-8 flex flex-row items-center justify-around">
       {zipSizeIDs.map(([sz, id]) => (
@@ -149,20 +135,6 @@ const AllButtonsWithAlertTemplate: ComponentStory<typeof Avatar> = () => (
         <Avatar
           id={id}
           style="identicon"
-          imgSrc={undefined}
-          decoration="alert"
-          size={sz}
-          key={sz}
-        />
-      ))}
-    </div>
-
-    <h1 className="text-xl">Jdenticon with alert</h1>
-    <div className="mb-8 flex flex-row items-center justify-around">
-      {zipSizeIDs.map(([sz, id]) => (
-        <Avatar
-          id={id}
-          style="jdenticon"
           imgSrc={undefined}
           decoration="alert"
           size={sz}

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,11 +1,9 @@
 import "@/index.css";
 
 import { useMemo } from "react";
-import type { Style, StyleOptions, Options } from "@dicebear/avatars";
-import { createAvatar } from "@dicebear/avatars";
-import * as bottts from "@dicebear/avatars-bottts-sprites";
-import * as identicon from "@dicebear/avatars-identicon-sprites";
-import * as jdenticon from "@dicebear/avatars-jdenticon-sprites";
+import type { Style, StyleOptions, Options } from "@dicebear/core";
+import { createAvatar } from "@dicebear/core";
+import { bottts, identicon } from "@dicebear/collection";
 import type { AvatarStyle } from "@/Types";
 import classNames from "classnames";
 
@@ -82,8 +80,6 @@ export const avatarStyle = (
       return bottts;
     case "identicon":
       return identicon;
-    case "jdenticon":
-      return jdenticon;
   }
 };
 
@@ -105,9 +101,8 @@ export const Avatar = (p: AvatarProps): JSX.Element => {
   const avatar = useMemo(() => {
     return createAvatar(avatarStyle(p.style), {
       seed: p.id,
-      dataUri: true,
       ...avatarOptions(p.style),
-    });
+    }).toDataUriSync();
   }, [p.id, p.style]);
   const src = p.imgSrc ? p.imgSrc : avatar;
 

--- a/src/components/examples/accounts.ts
+++ b/src/components/examples/accounts.ts
@@ -3,7 +3,7 @@ import type { Account } from "@/Types";
 export const exampleAccount: Account = {
   name: "Chelsea Hagon",
   email: "chelseahagon@example.com",
-  avatarStyle: "jdenticon",
+  avatarStyle: "identicon",
   imageUrl:
     "https://images.unsplash.com/photo-1573496358961-3c82861ab8f4?ixid=MnwyNjcwMzh8MHwxfGFsbHx8fHx8fHx8fDE2MzQwNTU4MjU&ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80",
 };


### PR DESCRIPTION
The packages we were using are no longer maintained. The replacement
packages have a slightly different API, and have dropped support for
the `jdenticon` style, unfortunately. We could add this back by using
the `jdenticon` package directly, but it would complicate the `Avatar`
type and isn't worth the time investment, for now.

Signed-off-by: Drew Hess <src@drewhess.com>
