### PR TITLE
chore: disable IBM OpenAPI validator warnings

### DIFF
--- a/orval.config.ts
+++ b/orval.config.ts
@@ -28,7 +28,9 @@ export default defineConfig({
   "primer-api": {
     input: {
       target: "./primer-api.json",
-      validation: true,
+      // Disabled until we can deal with the myriad validation issues
+      // that the IBM OpenAPI validator raises.
+      validation: false,
     },
     output: {
       mode: "split",


### PR DESCRIPTION
Maybe we'll pay more attention to these at a later date, but for now they're just an annoyance.