### PR TITLE
feat: set an `id` cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "fp-ts": "^2.16.0",
     "history": "^5.3.0",
     "react": "^18.2.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.44.1",
     "react-router-dom": "^6.11.2",
     "reactflow": "^11.7.2",
+    "universal-cookie": "^4.0.4",
     "uuid": "^9.0.0",
     "zod": "^3.21.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   react:
     specifier: ^18.2.0
     version: 18.2.0
+  react-cookie:
+    specifier: ^4.1.1
+    version: 4.1.1(react@18.2.0)
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
@@ -56,6 +59,9 @@ dependencies:
   reactflow:
     specifier: ^11.7.2
     version: 11.7.2(react-dom@18.2.0)(react@18.2.0)
+  universal-cookie:
+    specifier: ^4.0.4
+    version: 4.0.4
   uuid:
     specifier: ^9.0.0
     version: 9.0.0
@@ -5611,6 +5617,10 @@ packages:
       '@types/node': 20.2.5
     dev: true
 
+  /@types/cookie@0.3.3:
+    resolution: {integrity: sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==}
+    dev: false
+
   /@types/d3-array@3.0.4:
     resolution: {integrity: sha512-nwvEkG9vYOc0Ic7G7kwgviY4AQlTfYGIZ0fqB7CQHXGyYM6nO7kJh5EguSNA3jfh4rq7Sb7eMVq8isuvg2/miQ==}
     dev: false
@@ -5898,6 +5908,13 @@ packages:
       '@types/node': 20.2.5
     dev: true
 
+  /@types/hoist-non-react-statics@3.3.1:
+    resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
+    dependencies:
+      '@types/react': 18.2.7
+      hoist-non-react-statics: 3.3.2
+    dev: false
+
   /@types/http-cache-semantics@4.0.1:
     resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
     dev: true
@@ -6004,7 +6021,6 @@ packages:
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -6026,7 +6042,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
-    dev: true
 
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -6036,7 +6051,6 @@ packages:
 
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
-    dev: true
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
@@ -7658,6 +7672,11 @@ packages:
   /cookie-signature@1.0.6:
     resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
     dev: true
+
+  /cookie@0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
@@ -9752,6 +9771,12 @@ packages:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
       '@babel/runtime': 7.20.6
+    dev: false
+
+  /hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
     dev: false
 
   /hosted-git-info@2.8.9:
@@ -12635,6 +12660,17 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
+  /react-cookie@4.1.1(react@18.2.0):
+    resolution: {integrity: sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==}
+    peerDependencies:
+      react: '>= 16.3.0'
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.1
+      hoist-non-react-statics: 3.3.2
+      react: 18.2.0
+      universal-cookie: 4.0.4
+    dev: false
+
   /react-docgen-typescript@2.2.2(typescript@4.9.5):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
@@ -14383,6 +14419,13 @@ packages:
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
     dev: true
+
+  /universal-cookie@4.0.4:
+    resolution: {integrity: sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==}
+    dependencies:
+      '@types/cookie': 0.3.3
+      cookie: 0.4.2
+    dev: false
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,27 @@
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import "@/index.css";
+
+import { NoMatch } from "@/components";
+import ChooseSession from "@/ChooseSession";
+import Edit from "@/Edit";
+
+const queryClient = new QueryClient();
+
+const App = (): JSX.Element => (
+  <BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <Routes>
+        <Route path="/" element={<Navigate to="/sessions" />} />
+        <Route path="/sessions">
+          <Route index element={<ChooseSession />} />
+          <Route path=":sessionId" element={<Edit />} />
+        </Route>
+        <Route path="*" element={<NoMatch />} />
+      </Routes>
+    </QueryClientProvider>
+  </BrowserRouter>
+);
+
+export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,9 @@
+import { useEffect } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CookiesProvider, useCookies } from "react-cookie";
+import { CookieSetOptions } from "universal-cookie";
+import { v4 as uuidv4 } from "uuid";
 
 import "@/index.css";
 
@@ -9,19 +13,46 @@ import Edit from "@/Edit";
 
 const queryClient = new QueryClient();
 
-const App = (): JSX.Element => (
-  <BrowserRouter>
-    <QueryClientProvider client={queryClient}>
-      <Routes>
-        <Route path="/" element={<Navigate to="/sessions" />} />
-        <Route path="/sessions">
-          <Route index element={<ChooseSession />} />
-          <Route path=":sessionId" element={<Edit />} />
-        </Route>
-        <Route path="*" element={<NoMatch />} />
-      </Routes>
-    </QueryClientProvider>
-  </BrowserRouter>
-);
+const idCookieOptions = (path: string): CookieSetOptions => {
+  const twoDaysInSeconds = 2 * 24 * 60 * 60;
+  const secure = import.meta.env["VITE_WITH_CREDENTIALS"] === "true";
+  return {
+    path: path,
+    maxAge: twoDaysInSeconds,
+    secure: secure,
+    sameSite: secure ? "strict" : "none",
+  };
+};
+
+const App = (): JSX.Element => {
+  const [cookies, setCookie] = useCookies(["id"]);
+
+  useEffect(() => {
+    if (!cookies.id) {
+      // This is a dummy cookie in lieu of a proper account system. We
+      // don't particularly care about this cookie expiring and/or
+      // being cleared.
+      const uuid = uuidv4();
+      setCookie("id", uuid, idCookieOptions("/"));
+    }
+  }, [cookies, setCookie]);
+
+  return (
+    <CookiesProvider>
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route path="/" element={<Navigate to="/sessions" />} />
+            <Route path="/sessions">
+              <Route index element={<ChooseSession />} />
+              <Route path=":sessionId" element={<Edit />} />
+            </Route>
+            <Route path="*" element={<NoMatch />} />
+          </Routes>
+        </QueryClientProvider>
+      </BrowserRouter>
+    </CookiesProvider>
+  );
+};
 
 export default App;

--- a/src/ChooseSession.tsx
+++ b/src/ChooseSession.tsx
@@ -1,5 +1,6 @@
 import type { MouseEventHandler } from "react";
 import { useState } from "react";
+import { useCookies } from "react-cookie";
 import type { SessionMeta } from "@/Types";
 import { exampleAccount, SessionsPage } from "@/components";
 import type {
@@ -18,6 +19,8 @@ import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 
 const ChooseSession = (): JSX.Element => {
+  const [cookies] = useCookies(["id"]);
+
   // NOTE: pagination in our API is 1-indexed.
   const [page, setPage] = useState(1);
   const [pageSize] = useState(20);
@@ -78,7 +81,7 @@ const ChooseSession = (): JSX.Element => {
 
   return (
     <SessionsPage
-      account={exampleAccount}
+      account={{ ...exampleAccount, id: cookies.id }}
       sessions={sessionsMeta}
       startIndex={startIndex}
       numItems={meta.pageSize}

--- a/src/Edit.tsx
+++ b/src/Edit.tsx
@@ -44,7 +44,7 @@ import {
 // hardcoded values (for now)
 const initialLevel: Level = "Expert";
 
-const App = (): JSX.Element => {
+const Edit = (): JSX.Element => {
   const params = useParams();
   const sessionId = params["sessionId"];
 
@@ -422,4 +422,4 @@ const ActionsListSelection = (p: {
   return <ActionPanel {...{ actions, ...p }} />;
 };
 
-export default App;
+export default Edit;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -3,10 +3,8 @@ export type AvatarStyle = "bottts" | "identicon";
 
 // Placeholder account type.
 export interface Account {
-  name: string;
-  email: string;
+  id: string;
   avatarStyle: AvatarStyle;
-  imageUrl: string | undefined;
 }
 
 // Placeholder type for our backend session type.

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -68,7 +68,7 @@ const decorationClasses = (size: Size, decoration: Decoration) =>
     "h-3 w-3": size === "xl",
     "h-3.5 w-3.5": size === "2xl",
     hidden: decoration === "plain",
-    "absolute top-0 right-0 block rounded-full ring-2 ring-white-primary bg-red-secondary":
+    "absolute top-0 right-0 block rounded-full ring-4 ring-white-primary bg-red-secondary":
       true,
   });
 

--- a/src/components/SessionsNavBar/index.tsx
+++ b/src/components/SessionsNavBar/index.tsx
@@ -59,9 +59,9 @@ export const SessionsNavBar = (p: SessionsNavBarProps): JSX.Element => (
             <Menu.Button className="flex rounded-full bg-white-primary focus:outline-none focus:ring-2 focus:ring-blue-primary focus:ring-offset-2">
               <span className="sr-only">Open account menu</span>
               <Avatar
-                id={p.account.email}
+                id={p.account.id}
                 style={p.account.avatarStyle}
-                imgSrc={p.account.imageUrl}
+                imgSrc={undefined}
                 decoration="plain"
                 size="responsive"
               />

--- a/src/components/SessionsNavBar/index.tsx
+++ b/src/components/SessionsNavBar/index.tsx
@@ -56,7 +56,7 @@ export const SessionsNavBar = (p: SessionsNavBarProps): JSX.Element => (
         {/* Profile dropdown */}
         <Menu as="div" className="relative shrink-0">
           <div>
-            <Menu.Button className="flex rounded-full bg-white-primary focus:outline-none focus:ring-2 focus:ring-blue-primary focus:ring-offset-2">
+            <Menu.Button className="flex rounded-full ring-2 ring-grey-quaternary focus:outline-none focus:ring-2 focus:ring-blue-primary focus:ring-offset-2">
               <span className="sr-only">Open account menu</span>
               <Avatar
                 id={p.account.id}

--- a/src/components/examples/accounts.ts
+++ b/src/components/examples/accounts.ts
@@ -1,9 +1,6 @@
 import type { Account } from "@/Types";
 
 export const exampleAccount: Account = {
-  name: "Chelsea Hagon",
-  email: "chelseahagon@example.com",
+  id: "1",
   avatarStyle: "identicon",
-  imageUrl:
-    "https://images.unsplash.com/photo-1573496358961-3c82861ab8f4?ixid=MnwyNjcwMzh8MHwxfGFsbHx8fHx8fHx8fDE2MzQwNTU4MjU&ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80",
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,8 @@
 import * as React from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import "./index.css";
 
-import { NoMatch } from "@/components";
-import ChooseSession from "./ChooseSession";
-import Edit from "./Edit";
+import App from "./App";
 
-const queryClient = new QueryClient();
 const rootElement: HTMLElement | null = document.getElementById("root");
 if (!rootElement) {
   throw new Error(
@@ -20,17 +14,6 @@ const root = createRoot(rootElement);
 
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <Routes>
-          <Route path="/" element={<Navigate to="/sessions" />} />
-          <Route path="/sessions">
-            <Route index element={<ChooseSession />} />
-            <Route path=":sessionId" element={<Edit />} />
-          </Route>
-          <Route path="*" element={<NoMatch />} />
-        </Routes>
-      </QueryClientProvider>
-    </BrowserRouter>
+    <App />
   </React.StrictMode>
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import "./index.css";
 
 import { NoMatch } from "@/components";
 import ChooseSession from "./ChooseSession";
-import App from "./App";
+import Edit from "./Edit";
 
 const queryClient = new QueryClient();
 const rootElement: HTMLElement | null = document.getElementById("root");
@@ -26,7 +26,7 @@ root.render(
           <Route path="/" element={<Navigate to="/sessions" />} />
           <Route path="/sessions">
             <Route index element={<ChooseSession />} />
-            <Route path=":sessionId" element={<App />} />
+            <Route path=":sessionId" element={<Edit />} />
           </Route>
           <Route path="*" element={<NoMatch />} />
         </Routes>


### PR DESCRIPTION
We use this cookie in lieu of a proper account system. No personally identifiable information is stored: it's just a random v4 UUID that gets set when the page is loaded, and expires after 2 days. In the app, we only use this to set the avatar image to something unique. In production deployments, this abstract cookie should also help us with load balancing, as we should be able to use it to pin the visitor to a particular instance.
