### PR TITLE
feat: scroll to typedef when its name is clicked

### DIFF
--- a/src/Edit.tsx
+++ b/src/Edit.tsx
@@ -217,6 +217,7 @@ const AppNoError = ({
   const canvasDimensions = useDimensions(canvasRef);
 
   const scrollToDefRef = useRef<ScrollToDef | undefined>(undefined);
+  const scrollToTypeDefRef = useRef<ScrollToDef | undefined>(undefined);
 
   return (
     <div className="grid h-screen grid-cols-[18rem_auto_20rem]">
@@ -245,7 +246,11 @@ const AppNoError = ({
             }
           }}
           onClickAddDef={onClickAddDef}
-          onClickTypeDef={(_label, _event) => ({})}
+          onClickTypeDef={(defName, _event) => {
+            if (scrollToTypeDefRef.current != undefined) {
+              scrollToTypeDefRef.current(defName);
+            }
+          }}
           onClickAddTypeDef={() => setShowCreateTypeDefModal(true)}
           shadowed={false}
           type="?"
@@ -316,6 +321,7 @@ const AppNoError = ({
         }
         <TreeReactFlow
           scrollToDefRef={scrollToDefRef}
+          scrollToTypeDefRef={scrollToTypeDefRef}
           {...defaultTreeReactFlowProps}
           {...(selection && { selection })}
           onNodeClick={(_e, sel) => sel && setSelection(sel)}

--- a/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
+++ b/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
@@ -29,6 +29,7 @@ export default {
 const props: Omit<TreeReactFlowProps, "defs" | "typeDefs" | "onNodeClick"> = {
   ...defaultTreeReactFlowProps,
   scrollToDefRef: { current: undefined },
+  scrollToTypeDefRef: { current: undefined },
   forestLayout: "Vertical",
 };
 


### PR DESCRIPTION
This mirrors the earlier scroll-to-definition feature.

Signed-off-by: Drew Hess <src@drewhess.com>
