### PR TITLE
fix: truncate names to fit their containers

### DIFF
--- a/src/components/ActionPanelButton/ActionPanelButton.stories.tsx
+++ b/src/components/ActionPanelButton/ActionPanelButton.stories.tsx
@@ -67,6 +67,27 @@ const AllButtonsTemplate: ComponentStory<typeof ActionPanelButton> = (args) => (
       />
     </div>
 
+    <h1 className="text-xl">Primary, name only, code</h1>
+    <div className="mb-8 mt-4 w-96">
+      <ActionPanelButton
+        {...args}
+        appearance="primary"
+        name={{ text: "x", style: "code" }}
+      />
+    </div>
+
+    <h1 className="text-xl">Primary, name only, code, long</h1>
+    <div className="mb-8 mt-4 w-96">
+      <ActionPanelButton
+        {...args}
+        appearance="primary"
+        name={{
+          text: "This is a really really really long and verbose name",
+          style: "code",
+        }}
+      />
+    </div>
+
     <h1 className="text-xl">Danger with name as prose</h1>
     <div className="mb-8 mt-4 w-96">
       <ActionPanelButton

--- a/src/components/ActionPanelButton/index.tsx
+++ b/src/components/ActionPanelButton/index.tsx
@@ -47,7 +47,7 @@ export const ActionPanelButton = (p: ActionPanelButtonProps): JSX.Element => {
           <div
             className={classNames(
               "mr-4 w-8 flex-none",
-              p.name.style === "code" ? "font-code" : "",
+              p.name.style === "code" ? "block truncate font-code" : "",
               p.description ? "text-left" : "grow text-center"
             )}
             aria-hidden="true"

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -30,8 +30,16 @@ export const Default: ComponentStory<typeof Sidebar> = (args: SidebarProps) => (
     <Sidebar
       {...args}
       prog={{
-        types: ["GoalOrMiss", "WinLoseDraw"],
-        defs: ["footballGame", "whatsopposite"],
+        types: [
+          "GoalOrMiss",
+          "A really really really really really long type name",
+          "WinLoseDraw",
+        ],
+        defs: [
+          "A really really really really quite long function name",
+          "footballGame",
+          "whatsopposite",
+        ],
         importedTypes: [],
         importedDefs: ["opposite"].concat(
           Array(30)

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -21,7 +21,7 @@ export type Prog = {
 const headerStyle = "pb-3 text-base lg:text-lg font-bold text-blue-primary";
 const subHeaderStyle = "mb-1 text-sm lg:text-base font-bold text-blue-primary";
 const itemStyle =
-  "font-code text-sm lg:text-base leading-5 text-left text-grey-secondary";
+  "block truncate font-code text-sm lg:text-base leading-5 text-left text-grey-secondary";
 
 export type SidebarProps = { initialMode: Tab } & TypesAndDefinitionsProps &
   InfoProps &

--- a/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
+++ b/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
@@ -10,6 +10,7 @@ import {
   tree3,
   tree4,
   tree5,
+  tree6,
   oddEvenTrees,
   oddEvenTreesMiscStyles,
 } from "@/components/examples/trees";
@@ -64,6 +65,14 @@ const def5 = {
   name: { qualifiedModule: [], baseName: "Example 5" },
   term: tree5,
   type_: emptyTypeTree("5"),
+};
+const def6 = {
+  name: {
+    qualifiedModule: [],
+    baseName: "Example 6 is really annoying because of its long name",
+  },
+  term: tree6,
+  type_: emptyTypeTree("6"),
 };
 const typeDef1: TypeDef = {
   name: { qualifiedModule: [], baseName: "Either-ish" },
@@ -222,6 +231,18 @@ export const Tree5: ComponentStory<typeof TreeReactFlow> = (
       contents: { def: def5.name, node: { nodeType: "BodyNode", meta: 503 } },
     },
   });
+export const Tree6: ComponentStory<typeof TreeReactFlow> = (
+  args: TreeReactFlowProps
+) =>
+  treeSized({
+    ...args,
+    defs: [def6],
+    typeDefs: [],
+    selection: {
+      tag: "SelectionDef",
+      contents: { def: def6.name, node: { nodeType: "BodyNode", meta: 503 } },
+    },
+  });
 export const TreeType1: ComponentStory<typeof TreeReactFlow> = (
   args: TreeReactFlowProps
 ) =>
@@ -242,7 +263,7 @@ export const AllTrees: ComponentStory<typeof TreeReactFlow> = (
 ) =>
   treeSized({
     ...args,
-    defs: [def1, def2, def3, def4, def5],
+    defs: [def1, def2, def3, def4, def5, def6],
     typeDefs: [typeDef1],
     selection: {
       tag: "SelectionDef",

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -140,7 +140,7 @@ const nodeTypes = {
       >
         <div
           className={classNames(
-            "font-code text-sm xl:text-base",
+            "block truncate px-1 font-code text-sm xl:text-base",
             flavorContentClasses(data.flavor)
           )}
         >
@@ -185,7 +185,7 @@ const nodeTypes = {
         {
           <div
             className={classNames(
-              "font-code text-sm xl:text-base",
+              "block truncate px-1 font-code text-sm xl:text-base",
               flavorContentClasses(data.flavor)
             )}
           >
@@ -259,7 +259,7 @@ const nodeTypes = {
           height: data.height,
         }}
       >
-        <div className="font-code text-4xl text-grey-tertiary">
+        <div className="block truncate px-1 font-code text-4xl text-grey-tertiary">
           {data.def.baseName}
         </div>
       </div>
@@ -288,7 +288,7 @@ const nodeTypes = {
           height: data.height,
         }}
       >
-        <div className="font-code text-4xl text-grey-tertiary">
+        <div className="block truncate px-1 font-code text-4xl text-grey-tertiary">
           {data.name.baseName}
         </div>
       </div>
@@ -320,7 +320,11 @@ const nodeTypes = {
         }}
       >
         {
-          <div className={classNames("font-code text-sm text-grey-tertiary")}>
+          <div
+            className={classNames(
+              "block truncate px-1 font-code text-sm text-grey-tertiary"
+            )}
+          >
             {data.name}
           </div>
         }
@@ -354,7 +358,7 @@ const nodeTypes = {
       >
         <div
           className={classNames(
-            "font-code text-sm",
+            "block truncate px-1 font-code text-sm",
             flavorContentClasses("Con")
           )}
         >

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -125,6 +125,7 @@ const nodeTypes = {
       {handle("target", Position.Top)}
       {handle("target", Position.Left)}
       <div
+        title={data.contents}
         className={classNames(
           {
             "ring-4 ring-offset-4": data.selected,
@@ -169,6 +170,7 @@ const nodeTypes = {
       {handle("target", Position.Top)}
       {handle("target", Position.Left)}
       <div
+        title={data.flavor}
         className={classNames(
           {
             "ring-4 ring-offset-4": data.selected,
@@ -244,6 +246,7 @@ const nodeTypes = {
   }) => (
     <>
       <div
+        title={data.def.baseName}
         className={classNames(
           "flex items-center justify-center",
           "rounded-md",
@@ -273,6 +276,7 @@ const nodeTypes = {
   }) => (
     <>
       <div
+        title={data.name.baseName}
         className={classNames(
           "flex items-center justify-center",
           "rounded-md",
@@ -304,6 +308,7 @@ const nodeTypes = {
     <>
       {handle("target", Position.Left)}
       <div
+        title={data.name}
         className={classNames(
           "flex items-center justify-center",
           "rounded-md",
@@ -342,6 +347,7 @@ const nodeTypes = {
       {handle("target", Position.Top)}
       {handle("target", Position.Left)}
       <div
+        title={data.name.baseName}
         className={classNames(
           "flex items-center justify-center",
           "rounded-md",

--- a/src/components/examples/trees.ts
+++ b/src/components/examples/trees.ts
@@ -158,6 +158,46 @@ export const tree5: Tree = {
   nodeId: "500",
 };
 
+export const tree6: Tree = {
+  body: {
+    tag: "TextBody",
+    contents: {
+      fst: "Lam",
+      snd: { baseName: "a very very very long variable name" },
+    },
+  },
+  childTrees: [
+    {
+      body: { tag: "NoBody", contents: "Case" },
+      childTrees: [
+        {
+          body: {
+            tag: "TextBody",
+            contents: {
+              fst: "LocalVar",
+              snd: { baseName: "a very very very long variable name" },
+            },
+          },
+          childTrees: [],
+          nodeId: "602",
+        },
+        {
+          body: { tag: "NoBody", contents: "EmptyHole" },
+          childTrees: [],
+          nodeId: "603",
+        },
+        {
+          body: { tag: "NoBody", contents: "EmptyHole" },
+          childTrees: [],
+          nodeId: "606",
+        },
+      ],
+      nodeId: "601",
+    },
+  ],
+  nodeId: "600",
+};
+
 export const oddEvenTrees: [string, Tree][] = [
   [
     "even",


### PR DESCRIPTION
This fixes what is, IMO, our most egregious visual UI issue, which is that long names (variables, definitions, etc.) aren't clipped to fit their container boundaries. In some cases, such as action panel buttons, this is a minor annoyance, but in the case of React Flow trees, it's absolutely awful.

I believe this PR covers all cases where names can appear. It also adds tooltip support for React Flow nodes, where names are more likely to be clipped. The tooltips are also useful for cases where the tree has been zoomed out such that node labels are no longer legible.