### PR TITLE
chore: Allow building with Node 19 and 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "sideEffects": false,
   "engines": {
-    "node": "^18.6.0",
+    "node": "^18.6.0 || ^19.0 || ^20.0",
     "pnpm": "^8.5"
   },
   "scripts": {


### PR DESCRIPTION
This stems from trying to develop on my Arch-Linux-based personal laptop, without using Nix. Partly just out of curiosity, partly to see whether external contributors might be able to get away with not using Nix, and partly because using Nix has been more help than hindrance so far for the particular work I've wanted to do on that machine.

We will likely never reflect the full version ranges we _could_ use, across all dependencies, and Nix will remain the recommended way to build the app. But there's no harm in widening some bounds slightly when we know they work.

I considered also adding `"node": "*"` under the `"overrides"` section, which allows us to run `pnpm install`. But this isn't actually necessary for the more common `pnpm build` and `pnpm watch` steps, so I've left it out for now. We'd be better off just modifying our `tidy` fork to expand the range as with this PR anyway. Besides, the "engines" section is ["advisory only" and ignored outside of local development](https://pnpm.io/package_json#engines). In fact, it's a bit of a surprise that the way we import Tidy, it is considered "local" for these purposes.