### PR TITLE
fix: re-fit `EvalFull` trees when the selected definition changes

### DIFF
--- a/src/Edit.tsx
+++ b/src/Edit.tsx
@@ -334,7 +334,7 @@ const AppNoError = ({
           defs={p.module.defs}
           typeDefs={p.module.types}
           level={level}
-          zoomBarProps={{}}
+          fitViewParams={{}}
         />
       </div>
 

--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -23,7 +23,7 @@ const Evaluated = (p: {
       {...defaultTreeReactFlowProps}
       {...(p?.evaluated ? { tree: p?.evaluated?.contents } : {})}
       level={p.level}
-      fitViewParams={{ padding: 3.0 }}
+      fitViewParams={{ padding: 1.0 }}
     />
   );
 };

--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -56,6 +56,7 @@ export const EvalFull = ({
         <>
           <div className="grow">
             <Evaluated
+              key={evalDef}
               defName={{ qualifiedModule: moduleName, baseName: evalDef }}
               {...(evalFull.result ? { evaluated: evalFull.result } : {})}
               level={level}

--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -23,7 +23,7 @@ const Evaluated = (p: {
       {...defaultTreeReactFlowProps}
       {...(p?.evaluated ? { tree: p?.evaluated?.contents } : {})}
       level={p.level}
-      zoomBarProps={{ padding: 3.0 }}
+      fitViewParams={{ padding: 3.0 }}
     />
   );
 };

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -61,7 +61,7 @@ import {
   flavorLabelClasses,
   noBodyFlavorContents,
 } from "./Flavor";
-import { ZoomBar, ZoomBarProps } from "./ZoomBar";
+import { ZoomBar } from "./ZoomBar";
 import { WasmLayoutType } from "@zxch3n/tidy/wasm_dist";
 import { deepEqualTyped, usePromise } from "@/util";
 import { mapSnd } from "fp-ts/lib/Tuple";
@@ -79,6 +79,9 @@ type NodeParams = {
 type DefParams = {
   nameNodeMultipliers: { width: number; height: number };
 };
+export type FitViewParams = {
+  padding?: number;
+};
 export type TreeReactFlowProps = {
   defs: Def[];
   typeDefs: TypeDef[];
@@ -92,7 +95,7 @@ export type TreeReactFlowProps = {
   layout: LayoutParams;
   scrollToDefRef: MutableRefObject<ScrollToDef | undefined>;
   scrollToTypeDefRef: MutableRefObject<ScrollToDef | undefined>;
-  zoomBarProps: ZoomBarProps;
+  fitViewParams: FitViewParams | undefined;
 } & NodeParams;
 export const defaultTreeReactFlowProps: Pick<
   TreeReactFlowProps,
@@ -1033,7 +1036,7 @@ export const TreeReactFlow = (p: TreeReactFlowProps) => (
     onNodeClick={(mouseEvent, node) =>
       p.onNodeClick(mouseEvent, makeSelectionFromNode(node))
     }
-    zoomBarProps={p.zoomBarProps}
+    fitViewParams={p.fitViewParams}
   >
     <SetTreeReactFlowCallbacks
       scrollToDefRef={p.scrollToDefRef}
@@ -1047,7 +1050,7 @@ export type TreeReactFlowOneProps = {
   tree?: APITree;
   onNodeClick?: (event: React.MouseEvent, node: Positioned<PrimerNode>) => void;
   layout: LayoutParams;
-  zoomBarProps: ZoomBarProps;
+  fitViewParams: FitViewParams | undefined;
 } & NodeParams;
 
 /** Renders one `APITree` (e.g. one type or one term) on its own individual canvas.
@@ -1068,7 +1071,7 @@ export const TreeReactFlowOne = (p: TreeReactFlowOneProps) => (
         : new Promise(() => [])
     }
     {...(p.onNodeClick && { onNodeClick: p.onNodeClick })}
-    zoomBarProps={p.zoomBarProps}
+    fitViewParams={p.fitViewParams}
   ></Trees>
 );
 
@@ -1081,7 +1084,7 @@ const Trees = <N,>(
       event: React.MouseEvent,
       node: Positioned<PrimerNode<N>>
     ) => void;
-    zoomBarProps: ZoomBarProps;
+    fitViewParams: FitViewParams | undefined;
   }>
 ): JSX.Element => {
   const trees = usePromise([], p.makeTrees);
@@ -1104,9 +1107,10 @@ const Trees = <N,>(
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       proOptions={{ hideAttribution: true, account: "paid-pro" }}
+      fitViewOptions={{ ...p.fitViewParams }}
     >
       <Background gap={25} size={1.6} color="#81818a" />
-      <ZoomBar {...p.zoomBarProps} />
+      <ZoomBar {...p.fitViewParams} />
       {p.children}
     </ReactFlowSafe>
   );


### PR DESCRIPTION
*Note to reviewers: please hold off while I look into refactoring this.*

This turned out to be a simple fix: just set the `key` on the component that's responsible for rendering the tree and tie it to the selection value.

Re-fitting when the definition's value changes will be trickier. The most straightforward way is probably to hook the async/promise, but our bespoke caching makes this non-trivial, so this is left for future work.