### PR TITLE
fix: add `children` support to `TreeReactFlow`

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/primer-api";
 import {
   ReactFlow,
+  ReactFlowProvider,
   Node as RFNode,
   Edge as RFEdge,
   Handle,
@@ -974,7 +975,7 @@ const typeDefToTree = async (
  * It ensures that these are clearly displayed as "one atomic thing",
  * i.e. to avoid confused readings that group the type of 'foo' with the body of 'bar' (etc).
  */
-export const TreeReactFlow = (p: TreeReactFlowProps) => (
+export const TreeReactFlow = (p: PropsWithChildren<TreeReactFlowProps>) => (
   <Trees
     makeTrees={Promise.all([
       ...p.typeDefs.map((def) =>
@@ -1042,6 +1043,7 @@ export const TreeReactFlow = (p: TreeReactFlowProps) => (
       scrollToDefRef={p.scrollToDefRef}
       scrollToTypeDefRef={p.scrollToTypeDefRef}
     />
+    {p.children}
   </Trees>
 );
 export default TreeReactFlow;
@@ -1099,20 +1101,22 @@ const Trees = <N,>(
   const id = useId();
 
   return (
-    <ReactFlowSafe<Positioned<PrimerNode<N>>, PrimerEdge>
-      id={id}
-      {...(p.onNodeClick && { onNodeClick: p.onNodeClick })}
-      nodes={nodes}
-      edges={edges}
-      nodeTypes={nodeTypes}
-      edgeTypes={edgeTypes}
-      proOptions={{ hideAttribution: true, account: "paid-pro" }}
-      fitViewOptions={{ ...p.fitViewParams }}
-    >
-      <Background gap={25} size={1.6} color="#81818a" />
-      <ZoomBar {...p.fitViewParams} />
-      {p.children}
-    </ReactFlowSafe>
+    <ReactFlowProvider>
+      <ReactFlowSafe<Positioned<PrimerNode<N>>, PrimerEdge>
+        id={id}
+        {...(p.onNodeClick && { onNodeClick: p.onNodeClick })}
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        proOptions={{ hideAttribution: true, account: "paid-pro" }}
+        fitViewOptions={{ ...p.fitViewParams }}
+      >
+        <Background gap={25} size={1.6} color="#81818a" />
+        <ZoomBar {...p.fitViewParams} />
+        {p.children}
+      </ReactFlowSafe>
+    </ReactFlowProvider>
   );
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,5 @@
 import deepEqual from "deep-equal";
-import {
-  RefObject,
-  useEffect,
-  useMemo,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useEffect, useState } from "react";
 
 /** Evaluates to the type `true` when both parameters are equal, and `false` otherwise.
  * NB. this actually tests mutual extendability, which is mostly a reasonable definition of
@@ -24,23 +18,6 @@ export type Equal<T, S> = [T] extends [S]
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
 export const assertType = <T extends true>() => {};
-
-function subscribe(callback: (e: Event) => void) {
-  window.addEventListener("resize", callback);
-  return () => {
-    window.removeEventListener("resize", callback);
-  };
-}
-
-export function useDimensions(ref: RefObject<HTMLElement>) {
-  const dimensions = useSyncExternalStore(subscribe, () =>
-    JSON.stringify({
-      width: ref.current?.offsetWidth ?? 0,
-      height: ref.current?.offsetHeight ?? 0,
-    })
-  );
-  return useMemo(() => JSON.parse(dimensions), [dimensions]);
-}
 
 /** Use some initial data, while waiting for an asynchronous update.
  * This encapsulates a common React pattern, which may eventually have a built-in solution:


### PR DESCRIPTION
*Note to reviewers: please hold off while I look into refactoring this.*

With this change, we can render React components inside the start and
end of a `TreeReactFlow` component. Among other things, this removes a
bunch of hacks we needed to asynchronously determine the size of the
canvas and re-render components when it changes.

Now that we can parent one `TreeReactFlow` inside another, we need to
add a `ReactFlowProvider` around each use of `ReactFlow` (aka
`ReactFlowSafe`) in order for them to coexist. At the moment, this is
done internally in the `TreeReactFlow` implementation, but we may want
to move this outside and make it the caller's responsibility, if we
need more flexibility later (e.g., to reference `ReactFlow` internals
from other UI widgets).
