### PR TITLE
fix: re-fit the selected `EvalFull` def whenever its value changes

### DIFF
--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -24,6 +24,7 @@ const Evaluated = (p: {
       {...(p?.evaluated ? { tree: p?.evaluated?.contents } : {})}
       level={p.level}
       fitViewParams={{ padding: 1.0 }}
+      fitOnChange={true}
     />
   );
 };


### PR DESCRIPTION
We hook the `onNodesChange` property of `ReactFlow` to re-fit the evaluated tree whenever its nodes change as the result of an updated evaluation. This guarantees that the current evaluation result is always nicely fitted to the view upon initial viewing and/or evaluation update.

Notes on the implementation:

* We do this via a simple `fitOnChange?: boolean` property on `TreeReactFlowOne`. We could instead directly expose `onNodesChange`, but we have a lot of wrappers around `ReactFlow` and this would be fairly cumbersome to plumb through the depths. It would also require the caller to have fairly intimate understanding of how & where to use `ReactFlowProvider` and `useReactFlow`, so for now, we error on the side of simplicity for the caller.

* We don't make this feature available on `TreeReactFlow`, though it would be trivial to do so, because we don't anticipate that this feature will be desirable when editing definitions on the canvas.

* In order to implement this feature, we need to move the `ReactFlowProvider` brackets we recently added in a previous commit, because we now need to call `useReactFlow` from the `Tree` component. Most of the diff in this commit is due to indentation churn: it's probably best to review this commit with whitespace diffs disabled.