### PR TITLE
feat: add `children` support to `TreeReactFlow` and `TreeReactFlowOne`

### DIFF
--- a/src/Edit.tsx
+++ b/src/Edit.tsx
@@ -13,9 +13,9 @@ import {
   useQueryClient,
   UseQueryResult,
 } from "@tanstack/react-query";
-import { DependencyList, RefObject, useEffect, useRef, useState } from "react";
+import { DependencyList, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { useDimensions } from "./util";
+import { ReactFlowProvider } from "reactflow";
 import {
   useGetAvailableActions,
   useGetProgram,
@@ -214,9 +214,6 @@ const AppNoError = ({
     [p.module]
   );
 
-  const canvasRef: RefObject<HTMLDivElement> = useRef(null);
-  const canvasDimensions = useDimensions(canvasRef);
-
   const scrollToDefRef = useRef<ScrollToDef | undefined>(undefined);
   const scrollToTypeDefRef = useRef<ScrollToDef | undefined>(undefined);
   const defs = p.module.defs
@@ -259,83 +256,59 @@ const AppNoError = ({
         />
       </div>
 
-      <div className="relative h-full" ref={canvasRef}>
-        {
-          // Wait for the `div` above to be rendered before we create
-          // the floating toolbar element, otherwise its initial
-          // position will always be (0,0).
-          //
-          // Note that we should probably make this check something
-          // like `canvasDimensions.width < n`, where `n` is some
-          // minimum breakpoint beneath which we draw a non-floating
-          // element(s), instead of the floating toolbar. This is for
-          // 2 reasons:
-          //
-          // 1. A floating toolbar doesn't make much sense on small
-          // mobile devices. See:
-          // https://github.com/hackworthltd/primer-app/issues/836
-          //
-          // 2. `@neodrag/react` has undefined behavior when parented
-          // to an element that's smaller than the draggable.
-          //
-          // But we keep it simple for now until we've figured out
-          // what to do about mobile form factors.
-          canvasDimensions.width == 0 ? (
-            <></>
-          ) : (
-            <>
-              <div className="absolute bottom-4 right-4 z-30">
-                <Toolbar
-                  onModeChange={() => {
-                    console.log("Toggle mode");
-                  }}
-                  level={level}
-                  onLevelChange={toggleLevel}
-                  undoAvailable={p.undoAvailable}
-                  onClickUndo={() => {
-                    undo
-                      .mutateAsync({
-                        sessionId: p.sessionId,
-                      })
-                      .then(p.setProg);
-                  }}
-                  redoAvailable={p.redoAvailable}
-                  onClickRedo={() => {
-                    redo
-                      .mutateAsync({
-                        sessionId: p.sessionId,
-                      })
-                      .then(p.setProg);
-                  }}
-                  initialMode="tree"
-                />
-              </div>
-
-              <PictureInPicture
-                level={level}
-                // Note: these offsets are rather arbitrary.
-                initialPosition={{ x: 10, y: 10 }}
-                moduleName={p.module.modname}
-                evalFull={{
-                  request: setEvalTarget,
-                  ...(evalResult.isSuccess ? { result: evalResult.data } : {}),
+      <div className="relative h-full">
+        <ReactFlowProvider>
+          <TreeReactFlow
+            scrollToDefRef={scrollToDefRef}
+            scrollToTypeDefRef={scrollToTypeDefRef}
+            {...defaultTreeReactFlowProps}
+            {...(selection && { selection })}
+            onNodeClick={(_e, sel) => sel && setSelection(sel)}
+            defs={p.module.defs}
+            typeDefs={p.module.types}
+            level={level}
+            zoomBarProps={{}}
+          >
+            <div className="absolute bottom-4 right-4 z-30">
+              <Toolbar
+                onModeChange={() => {
+                  console.log("Toggle mode");
                 }}
-                defs={defs}
+                level={level}
+                onLevelChange={toggleLevel}
+                undoAvailable={p.undoAvailable}
+                onClickUndo={() => {
+                  undo
+                    .mutateAsync({
+                      sessionId: p.sessionId,
+                    })
+                    .then(p.setProg);
+                }}
+                redoAvailable={p.redoAvailable}
+                onClickRedo={() => {
+                  redo
+                    .mutateAsync({
+                      sessionId: p.sessionId,
+                    })
+                    .then(p.setProg);
+                }}
+                initialMode="tree"
               />
-            </>
-          )
-        }
-        <TreeReactFlow
-          scrollToDefRef={scrollToDefRef}
-          scrollToTypeDefRef={scrollToTypeDefRef}
-          {...defaultTreeReactFlowProps}
-          {...(selection && { selection })}
-          onNodeClick={(_e, sel) => sel && setSelection(sel)}
-          defs={p.module.defs}
-          typeDefs={p.module.types}
-          level={level}
-          zoomBarProps={{}}
-        />
+            </div>
+
+            <PictureInPicture
+              level={level}
+              // Note: these offsets are rather arbitrary.
+              initialPosition={{ x: 10, y: 10 }}
+              moduleName={p.module.modname}
+              evalFull={{
+                request: setEvalTarget,
+                ...(evalResult.isSuccess ? { result: evalResult.data } : {}),
+              }}
+              defs={defs}
+            />
+          </TreeReactFlow>
+        </ReactFlowProvider>
       </div>
 
       <div className="h-full overflow-hidden">

--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ReactFlowProvider } from "reactflow";
 import { EvalFullResp, GlobalName, Level } from "@/primer-api";
 import { SelectMenu, TreeReactFlowOne } from "@/components";
 import { defaultTreeReactFlowProps } from "../TreeReactFlow";
@@ -55,11 +56,13 @@ export const EvalFull = ({
       {evalDef !== disableEval && (
         <>
           <div className="grow">
-            <Evaluated
-              defName={{ qualifiedModule: moduleName, baseName: evalDef }}
-              {...(evalFull.result ? { evaluated: evalFull.result } : {})}
-              level={level}
-            />
+            <ReactFlowProvider>
+              <Evaluated
+                defName={{ qualifiedModule: moduleName, baseName: evalDef }}
+                {...(evalFull.result ? { evaluated: evalFull.result } : {})}
+                level={level}
+              />
+            </ReactFlowProvider>
           </div>
         </>
       )}

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -971,7 +971,7 @@ const typeDefToTree = async (
  * It ensures that these are clearly displayed as "one atomic thing",
  * i.e. to avoid confused readings that group the type of 'foo' with the body of 'bar' (etc).
  */
-export const TreeReactFlow = (p: TreeReactFlowProps) => (
+export const TreeReactFlow = (p: PropsWithChildren<TreeReactFlowProps>) => (
   <Trees
     makeTrees={Promise.all([
       ...p.typeDefs.map((def) =>
@@ -1039,6 +1039,7 @@ export const TreeReactFlow = (p: TreeReactFlowProps) => (
       scrollToDefRef={p.scrollToDefRef}
       scrollToTypeDefRef={p.scrollToTypeDefRef}
     />
+    {p.children}
   </Trees>
 );
 export default TreeReactFlow;
@@ -1053,7 +1054,9 @@ export type TreeReactFlowOneProps = {
 /** Renders one `APITree` (e.g. one type or one term) on its own individual canvas.
  * This is essentially a much simpler version of `TreeReactFlow`.
  */
-export const TreeReactFlowOne = (p: TreeReactFlowOneProps) => (
+export const TreeReactFlowOne = (
+  p: PropsWithChildren<TreeReactFlowOneProps>
+) => (
   <Trees
     makeTrees={
       p.tree
@@ -1069,7 +1072,9 @@ export const TreeReactFlowOne = (p: TreeReactFlowOneProps) => (
     }
     {...(p.onNodeClick && { onNodeClick: p.onNodeClick })}
     zoomBarProps={p.zoomBarProps}
-  ></Trees>
+  >
+    {p.children}
+  </Trees>
 );
 
 // The core of our interaction with ReactFlow: take some abstract trees, and render them.

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,5 @@
 import deepEqual from "deep-equal";
-import {
-  RefObject,
-  useEffect,
-  useMemo,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useEffect, useState } from "react";
 
 /** Evaluates to the type `true` when both parameters are equal, and `false` otherwise.
  * NB. this actually tests mutual extendability, which is mostly a reasonable definition of
@@ -24,23 +18,6 @@ export type Equal<T, S> = [T] extends [S]
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
 export const assertType = <T extends true>() => {};
-
-function subscribe(callback: (e: Event) => void) {
-  window.addEventListener("resize", callback);
-  return () => {
-    window.removeEventListener("resize", callback);
-  };
-}
-
-export function useDimensions(ref: RefObject<HTMLElement>) {
-  const dimensions = useSyncExternalStore(subscribe, () =>
-    JSON.stringify({
-      width: ref.current?.offsetWidth ?? 0,
-      height: ref.current?.offsetHeight ?? 0,
-    })
-  );
-  return useMemo(() => JSON.parse(dimensions), [dimensions]);
-}
 
 /** Use some initial data, while waiting for an asynchronous update.
  * This encapsulates a common React pattern, which may eventually have a built-in solution:


### PR DESCRIPTION
With this change, we can parent React components to `TreeReactFlow` and `TreeReactFlowOne`. Among other things, this removes a bunch of hacks we needed to asynchronously determine the size of the canvas when rendering the `PictureInPicture` and `Toolbar` components, which overlay it.

Now that we can parent one `TreeReactFlow` inside another, we need to add a `ReactFlowProvider` around each nested use of React Flow in order for them to coexist. This is the responsibility of the caller to get right, the advantage being that we can now get & use internal React Flow state from pretty much anywhere.