### PR TITLE
fix: re-fit live eval results when they change

### DIFF
--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -65,6 +65,7 @@ export const EvalFull = ({
           <div className="grow">
             <ReactFlowProvider>
               <Evaluated
+                key={evalDef}
                 defName={{ qualifiedModule: moduleName, baseName: evalDef }}
                 {...(evalFull.result ? { evaluated: evalFull.result } : {})}
                 level={level}

--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -19,7 +19,7 @@ const Evaluated = (p: {
   evaluated?: EvalFullResp;
   level: Level;
 }) => {
-  const padding = 3.0;
+  const padding = 1.0;
   const { fitView } = useReactFlow();
   const onNodesChange = (_: NodeChange[]) => {
     fitView({ padding });

--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ReactFlowProvider } from "reactflow";
+import { NodeChange, ReactFlowProvider, useReactFlow } from "reactflow";
 import { EvalFullResp, GlobalName, Level } from "@/primer-api";
 import { SelectMenu, TreeReactFlowOne } from "@/components";
 import { defaultTreeReactFlowProps } from "../TreeReactFlow";
@@ -19,12 +19,19 @@ const Evaluated = (p: {
   evaluated?: EvalFullResp;
   level: Level;
 }) => {
+  const padding = 3.0;
+  const { fitView } = useReactFlow();
+  const onNodesChange = (_: NodeChange[]) => {
+    fitView({ padding });
+  };
+
   return (
     <TreeReactFlowOne
       {...defaultTreeReactFlowProps}
       {...(p?.evaluated ? { tree: p?.evaluated?.contents } : {})}
       level={p.level}
-      zoomBarProps={{ padding: 3.0 }}
+      zoomBarProps={{ padding }}
+      onNodesChange={onNodesChange}
     />
   );
 };


### PR DESCRIPTION
This series of commits fixes the issue where the live eval results in the `PictureInPicture` window weren't nicely re-fitted whenever the definition selection changed, nor when the definition's value changed due to an edit.
