### PR TITLE
feat: support new typedef actions

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-fdcdd6c7bda329fe164855f700386a500ebeaf00
+          image: ghcr.io/hackworthltd/primer-service-dev:git-026a3490d29d3ea7841d185930c3467bb3133831
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -1678,17 +1678,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1686222601,
-        "narHash": "sha256-qeOpNpHNcqYel4V4ItjHWrXyHyO4McGbamvjSFgYAYo=",
+        "lastModified": 1686239602,
+        "narHash": "sha256-GKYY5w5TNK4vIq9zoX51ePT073J+zRgWcyXicDfWXIw=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "fdcdd6c7bda329fe164855f700386a500ebeaf00",
+        "rev": "026a3490d29d3ea7841d185930c3467bb3133831",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "fdcdd6c7bda329fe164855f700386a500ebeaf00",
+        "rev": "026a3490d29d3ea7841d185930c3467bb3133831",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/fdcdd6c7bda329fe164855f700386a500ebeaf00;
+    primer.url = github:hackworthltd/primer/026a3490d29d3ea7841d185930c3467bb3133831;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };

--- a/src/Actions.tsx
+++ b/src/Actions.tsx
@@ -41,6 +41,8 @@ export const actionName = (action: NoInputAction | InputAction): Name => {
       return prose("↑");
     case "DeleteDef":
       return prose("⌫");
+    case "DeleteTypeDef":
+      return prose("⌫");
     case "DuplicateDef":
       return prose("d");
     case "DeleteType":
@@ -97,12 +99,20 @@ export const actionName = (action: NoInputAction | InputAction): Name => {
       return prose("r");
     case "AddCon":
       return prose("+");
+    case "DeleteCon":
+      return prose("⌫");
     case "RenameCon":
       return prose("r");
     case "RenameTypeParam":
       return prose("r");
+    case "AddTypeParam":
+      return prose("t");
+    case "DeleteTypeParam":
+      return prose("⌫");
     case "AddConField":
       return prose("+");
+    case "DeleteConField":
+      return prose("p⌫");
   }
 };
 
@@ -152,6 +162,8 @@ export const actionDescription = (
       return "Replace parent with this subtree";
     case "DeleteDef":
       return "Delete this definition";
+    case "DeleteTypeDef":
+      return "Delete this type definition";
     case "DuplicateDef":
       return "Duplicate this definition";
     case "DeleteType":
@@ -208,12 +220,20 @@ export const actionDescription = (
       return "Rename this type";
     case "AddCon":
       return "Add a constructor to this type";
+    case "DeleteCon":
+      return "Delete this constructor";
     case "RenameCon":
       return "Rename this constructor";
     case "RenameTypeParam":
       return "Rename this parameter";
+    case "AddTypeParam":
+      return "Add a type parameter";
+    case "DeleteTypeParam":
+      return "Delete this parameter";
     case "AddConField":
       return "Add a parameter to this constructor";
+    case "DeleteConField":
+      return "Delete this parameter";
   }
 };
 
@@ -248,6 +268,8 @@ export const actionType = (action: NoInputAction | InputAction): ActionType => {
     case "RaiseType":
       return "Destructive";
     case "DeleteDef":
+      return "Destructive";
+    case "DeleteTypeDef":
       return "Destructive";
     case "DuplicateDef":
       return "Primary";
@@ -305,11 +327,19 @@ export const actionType = (action: NoInputAction | InputAction): ActionType => {
       return "Primary";
     case "AddCon":
       return "Primary";
+    case "DeleteCon":
+      return "Destructive";
     case "RenameCon":
       return "Primary";
     case "RenameTypeParam":
       return "Primary";
+    case "AddTypeParam":
+      return "Primary";
+    case "DeleteTypeParam":
+      return "Destructive";
     case "AddConField":
       return "Primary";
+    case "DeleteConField":
+      return "Destructive";
   }
 };

--- a/src/primer-api/model/getActionOptionsAction.ts
+++ b/src/primer-api/model/getActionOptionsAction.ts
@@ -39,4 +39,5 @@ export const GetActionOptionsAction = {
   RenameCon: 'RenameCon',
   RenameTypeParam: 'RenameTypeParam',
   AddCon: 'AddCon',
+  AddTypeParam: 'AddTypeParam',
 } as const;

--- a/src/primer-api/model/inputAction.ts
+++ b/src/primer-api/model/inputAction.ts
@@ -39,4 +39,5 @@ export const InputAction = {
   RenameCon: 'RenameCon',
   RenameTypeParam: 'RenameTypeParam',
   AddCon: 'AddCon',
+  AddTypeParam: 'AddTypeParam',
 } as const;

--- a/src/primer-api/model/noInputAction.ts
+++ b/src/primer-api/model/noInputAction.ts
@@ -28,5 +28,9 @@ export const NoInputAction = {
   DeleteType: 'DeleteType',
   DuplicateDef: 'DuplicateDef',
   DeleteDef: 'DeleteDef',
+  DeleteTypeDef: 'DeleteTypeDef',
+  DeleteCon: 'DeleteCon',
   AddConField: 'AddConField',
+  DeleteConField: 'DeleteConField',
+  DeleteTypeParam: 'DeleteTypeParam',
 } as const;


### PR DESCRIPTION
This bumps the Primer pin to
`026a3490d29d3ea7841d185930c3467bb3133831`, which supports new typedef
actions (type parameters & deletion in additional scenarios).

(Note that the backend implementation is a bit buggy, but this is a
known issue.)

Signed-off-by: Drew Hess <src@drewhess.com>
