### PR TITLE
feat: add a drag bar to the PIP

### DIFF
--- a/src/components/PictureInPicture/index.tsx
+++ b/src/components/PictureInPicture/index.tsx
@@ -1,4 +1,5 @@
 import {
+  EllipsisHorizontalIcon,
   InformationCircleIcon,
   PlayCircleIcon,
 } from "@heroicons/react/24/outline";
@@ -52,56 +53,67 @@ export const PictureInPicture = (p: PictureInPictureProps): JSX.Element => {
     <div
       ref={draggableRef}
       className={classNames(
-        "w-full max-w-sm h-70 rounded bg-grey-primary absolute z-30",
+        "flex w-full flex-row max-w-sm h-70 rounded bg-grey-primary absolute z-30",
         touchDragging ? "shadow-2xl -my-1 -mx-2" : "shadow-lg"
       )}
     >
-      <Tab.Group defaultIndex={1}>
-        <Tab.List className="flex flex-row rounded pb-2">
-          <Tab className={({ selected }) => tabClasses(selected, "rounded-tl")}>
-            {({ selected }) =>
-              selected ? (
-                <div className="flex w-full flex-row items-center justify-center gap-x-2">
-                  <PlayCircleIconSolid className="h-8 fill-blue-primary" />
-                  <div>Evaluate</div>
-                </div>
-              ) : (
-                <div className="flex w-full flex-row items-center justify-center gap-x-2">
-                  <PlayCircleIcon className="h-8 text-grey-secondary" />
-                  <div>Evaluate</div>
-                </div>
-              )
-            }
-          </Tab>
-          <Tab className={({ selected }) => tabClasses(selected, "rounded-tr")}>
-            {({ selected }) =>
-              selected ? (
-                <div className="flex w-full flex-row items-center justify-center gap-x-2">
-                  <InformationCircleIconSolid className="h-8 fill-blue-primary" />
-                  <div>Selection info</div>
-                </div>
-              ) : (
-                <div className="flex w-full flex-row items-center justify-center gap-x-2">
-                  <InformationCircleIcon className="h-8 text-grey-secondary" />
-                  <div>Selection Info</div>
-                </div>
-              )
-            }
-          </Tab>
-        </Tab.List>
-        <Tab.Panels>
-          <Tab.Panel>
-            <div className="h-60">
-              <EvalFull {...p} />
-            </div>
-          </Tab.Panel>
-          <Tab.Panel>
-            <div className="h-60">
-              <SelectionInfo {...p} />
-            </div>
-          </Tab.Panel>
-        </Tab.Panels>
-      </Tab.Group>
+      <div className="grow">
+        <Tab.Group defaultIndex={1}>
+          <Tab.List className="flex flex-row rounded pb-2">
+            <Tab
+              className={({ selected }) => tabClasses(selected, "rounded-tl")}
+            >
+              {({ selected }) =>
+                selected ? (
+                  <div className="flex w-full flex-row items-center justify-center gap-x-2">
+                    <PlayCircleIconSolid className="h-8 fill-blue-primary" />
+                    <div>Evaluate</div>
+                  </div>
+                ) : (
+                  <div className="flex w-full flex-row items-center justify-center gap-x-2">
+                    <PlayCircleIcon className="h-8 text-grey-secondary" />
+                    <div>Evaluate</div>
+                  </div>
+                )
+              }
+            </Tab>
+            <Tab className={({ selected }) => tabClasses(selected)}>
+              {({ selected }) =>
+                selected ? (
+                  <div className="flex w-full flex-row items-center justify-center gap-x-2">
+                    <InformationCircleIconSolid className="h-8 fill-blue-primary" />
+                    <div>Selection info</div>
+                  </div>
+                ) : (
+                  <div className="flex w-full flex-row items-center justify-center gap-x-2">
+                    <InformationCircleIcon className="h-8 text-grey-secondary" />
+                    <div>Selection Info</div>
+                  </div>
+                )
+              }
+            </Tab>
+          </Tab.List>
+          <Tab.Panels>
+            <Tab.Panel>
+              <div className="h-60">
+                <EvalFull {...p} />
+              </div>
+            </Tab.Panel>
+            <Tab.Panel>
+              <div className="h-60">
+                <SelectionInfo {...p} />
+              </div>
+            </Tab.Panel>
+          </Tab.Panels>
+        </Tab.Group>
+      </div>
+      <div className="flex w-8 select-none flex-col items-center overflow-hidden rounded-r border-l border-grey-quaternary bg-grey-primary">
+        <div className="neodrag-react-handle flex w-6 flex-col">
+          <EllipsisHorizontalIcon className="stroke-grey-secondary" />
+          <EllipsisHorizontalIcon className="-mt-4 stroke-grey-secondary" />
+          <EllipsisHorizontalIcon className="-mt-4 stroke-grey-secondary" />
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
We put this on the right, rather than the conventional top. This is
for 2 reasons:

1. We're very vertically constrained already on typical 16:9 laptop
aspect ratios.

2. It leaves the door open for adding additional tools/controls,
toolbar-style.

Signed-off-by: Drew Hess <src@drewhess.com>
