### PR TITLE
fix: Ensure typedef param node IDs are unique

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -843,7 +843,8 @@ const typeDefToTree = async (
   const paramsTree = def.params.reduceRight<
     [T, (parentId: string) => E] | undefined
   >((child, name) => {
-    const id = "typedef-param-" + name;
+    const id =
+      "typedef-param-" + JSON.stringify({ def: def.name.baseName, name });
     const node: N = {
       id,
       type: "primer-typedef-param",


### PR DESCRIPTION
This was a pretty stupid bug (introduced by me). One of the small things I'd like to tackle after the demo push is factoring out our ID creation, frontend and backend, with a rough proof of uniqueness.