### PR TITLE
chore: bump Primer pin

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-a2724a0f08b7d50c15e497be1027567afdb7a581
+          image: ghcr.io/hackworthltd/primer-service-dev:git-026f3a0c616c8cd1a3857c9aba826b937258fb0e
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -1678,17 +1678,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1686319004,
-        "narHash": "sha256-0dgD6NmJQKm95HmSRBwDGSdq+3AgFTZ+yVC1IBeWRAQ=",
+        "lastModified": 1686367567,
+        "narHash": "sha256-0HaunfV7YyNFQW/52N+RbbuhDwYUAmD9n6Vg+hQqzDM=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "a2724a0f08b7d50c15e497be1027567afdb7a581",
+        "rev": "026f3a0c616c8cd1a3857c9aba826b937258fb0e",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "a2724a0f08b7d50c15e497be1027567afdb7a581",
+        "rev": "026f3a0c616c8cd1a3857c9aba826b937258fb0e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/a2724a0f08b7d50c15e497be1027567afdb7a581;
+    primer.url = github:hackworthltd/primer/026f3a0c616c8cd1a3857c9aba826b937258fb0e;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };


### PR DESCRIPTION
This version of Primer brings matching type info to value constructors
when they strictly match a hole's type, up to alpha. For example,
given a hole of type `Nat`, `Zero` will match, but `Succ` will not,
because `Succ` takes an argument of type `Nat`.

Signed-off-by: Drew Hess <src@drewhess.com>
