### PR TITLE
fix: Don't consider node's with undefined selection to be selected

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -507,10 +507,12 @@ const makePrimerNode = async (
     PrimerGraph[]
   ]
 > => {
-  const selected = deepEqualTyped(
-    def && makeSelectionFromNodeData(def, node.nodeId, nodeData),
-    p.selection
-  );
+  const selected =
+    p.selection != undefined &&
+    deepEqualTyped(
+      def && makeSelectionFromNodeData(def, node.nodeId, nodeData),
+      p.selection
+    );
   const id = node.nodeId;
   const common = {
     width: p.nodeWidth,


### PR DESCRIPTION
In practice, this removes unexpected rings around all nodes in the type display and eval trees.