### PR TITLE
ci: add a ZuriHac Pages deployment

### DIFF
--- a/.github/workflows/deploy-frontend-zurihac.yaml
+++ b/.github/workflows/deploy-frontend-zurihac.yaml
@@ -1,0 +1,25 @@
+name: Deploy the frontend (ZuriHac)
+
+on:
+  push:
+    branches:
+      - zurihac
+
+jobs:
+  build-frontend-zurihac:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-frontend.yaml
+    with:
+      api-url: "https://zurihac-api.hackworth.codes/"
+      withCredentials: true
+
+  deploy-frontend-zurihac:
+    needs: build-frontend-zurihac
+    permissions:
+      contents: read
+      id-token: write
+      deployments: write
+    uses: ./.github/workflows/deploy-frontend.yaml
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Push to the `zurihac` branch to activate.

Note that Cloudflare Pages can only point alias domains to "production" branch deployments, so we'll need to find another way to update the zurihac.hackworth.codes domain when a new deployment is made to this branch.