### PR TITLE
chore: bump Primer pin

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-a2724a0f08b7d50c15e497be1027567afdb7a581
+          image: ghcr.io/hackworthltd/primer-service-dev:git-6fd3dd07ffb1a89b77da9978b5406e61c4acaec7
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -1678,17 +1678,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1686319004,
-        "narHash": "sha256-0dgD6NmJQKm95HmSRBwDGSdq+3AgFTZ+yVC1IBeWRAQ=",
+        "lastModified": 1686400408,
+        "narHash": "sha256-e7Ih3Hbh5qQrbAUlqgJQVq81DuoMC1tbTlxBANSSFFE=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "a2724a0f08b7d50c15e497be1027567afdb7a581",
+        "rev": "6fd3dd07ffb1a89b77da9978b5406e61c4acaec7",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "a2724a0f08b7d50c15e497be1027567afdb7a581",
+        "rev": "6fd3dd07ffb1a89b77da9978b5406e61c4acaec7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/a2724a0f08b7d50c15e497be1027567afdb7a581;
+    primer.url = github:hackworthltd/primer/6fd3dd07ffb1a89b77da9978b5406e61c4acaec7;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };


### PR DESCRIPTION
This brings this repo up-to-date with `primer` upstream `main`. There are no frontend-visible changes here.