### PR TITLE
style: restyle definition & typedef nodes

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -274,12 +274,12 @@ const nodeTypes = {
         title={data.def.baseName}
         className={classNames(
           "flex items-center justify-center",
-          "rounded-md",
-          "bg-grey-primary",
-          "border-8 border-grey-tertiary ring-grey-tertiary",
+          "rounded-lg",
+          "bg-white-primary",
+          "border-4 border-blue-secondary ring-blue-secondary",
           data.selected && "ring-4 ring-offset-4",
           commonHoverClasses,
-          "hover:ring-grey-tertiary",
+          "hover:ring-blue-secondary",
           !data.selected && "hover:ring-opacity-50"
         )}
         style={{
@@ -287,7 +287,7 @@ const nodeTypes = {
           height: data.height,
         }}
       >
-        <div className="block truncate px-1 font-code text-4xl text-grey-tertiary">
+        <div className="block truncate px-2 font-code text-xl font-semibold text-blue-primary">
           {data.def.baseName}
         </div>
       </div>
@@ -305,11 +305,11 @@ const nodeTypes = {
         className={classNames(
           "flex items-center justify-center",
           "rounded-md",
-          "bg-grey-primary",
-          "border-8 border-grey-tertiary ring-grey-tertiary",
+          "bg-white-primary",
+          "border-4 border-grey-secondary ring-grey-secondary",
           data.selected && "ring-4 ring-offset-4",
           commonHoverClasses,
-          "hover:ring-grey-tertiary",
+          "hover:ring-grey-secondary",
           !data.selected && "hover:ring-opacity-50"
         )}
         style={{
@@ -317,7 +317,7 @@ const nodeTypes = {
           height: data.height,
         }}
       >
-        <div className="block truncate px-1 font-code text-4xl text-grey-tertiary">
+        <div className="block truncate px-2 font-code text-xl font-semibold text-blue-primary">
           {data.name.baseName}
         </div>
       </div>
@@ -337,11 +337,11 @@ const nodeTypes = {
         className={classNames(
           "flex items-center justify-center",
           "rounded-md",
-          "bg-grey-primary",
-          "border-4 border-grey-tertiary ring-grey-tertiary",
+          "bg-white-primary",
+          "border-4 border-grey-secondary ring-grey-secondary",
           data.selected && "ring-4 ring-offset-4",
           commonHoverClasses,
-          "hover:ring-grey-tertiary",
+          "hover:ring-grey-secondary",
           !data.selected && "hover:ring-opacity-50"
         )}
         style={{
@@ -352,7 +352,7 @@ const nodeTypes = {
         {
           <div
             className={classNames(
-              "block truncate px-1 font-code text-sm text-grey-tertiary"
+              "block truncate px-2 font-code text-sm text-blue-primary"
             )}
           >
             {data.name}


### PR DESCRIPTION
Mainly we bring the border styling in line with other nodes and make the label font less loud. I think we already draw enough attention to these special nodes due to their size, but here we also use a slightly "electric" border color and also increase the font size and weight a bit vs. normal nodes.

We've also increased contrast by ditching the grey background. (We would like to move towards a grey canvas background, anyway, so the old background color would have clashed.)

One drawback to the new style is that definition names are harder to see when zoomed out, but we have other ways to locate definitions (e.g., clicking on their names in the sidebar), and we have tooltips on hover, as well. (One benefit to making the font size smaller is that definition names can be longer before they're truncated.)