### PR TITLE
chore: bump Primer pin

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-6fd3dd07ffb1a89b77da9978b5406e61c4acaec7
+          image: ghcr.io/hackworthltd/primer-service-dev:git-41ee2a90cfd378a9fe054a18e9db7baaa1626207
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -1678,17 +1678,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1686400408,
-        "narHash": "sha256-e7Ih3Hbh5qQrbAUlqgJQVq81DuoMC1tbTlxBANSSFFE=",
+        "lastModified": 1686418053,
+        "narHash": "sha256-K9kB4W3OJyw1p0L8DBgQZhgyoj/8R8JaVwEJbpRu1aQ=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "6fd3dd07ffb1a89b77da9978b5406e61c4acaec7",
+        "rev": "41ee2a90cfd378a9fe054a18e9db7baaa1626207",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "6fd3dd07ffb1a89b77da9978b5406e61c4acaec7",
+        "rev": "41ee2a90cfd378a9fe054a18e9db7baaa1626207",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/6fd3dd07ffb1a89b77da9978b5406e61c4acaec7;
+    primer.url = github:hackworthltd/primer/41ee2a90cfd378a9fe054a18e9db7baaa1626207;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };


### PR DESCRIPTION
N.B.: we diverge from `primer` `main` for a bit, as the new pin here
is not ready for merging into upstream, but contains some important
fixes that we need for ZuriHac.

Signed-off-by: Drew Hess <src@drewhess.com>
