### PR TITLE
style: use Tailwind directive to get 100dvh support

### DIFF
--- a/src/Edit.tsx
+++ b/src/Edit.tsx
@@ -251,7 +251,7 @@ const AppNoError = ({
     .sort((a, b) => cmpName(a.name, b.name))
     .map((d) => d.name.baseName);
   return (
-    <div className="grid h-screen grid-cols-[auto_20rem]">
+    <div className="grid h-[100dvh] grid-cols-[auto_20rem]">
       <div className="relative h-full">
         <ReactFlowProvider>
           <TreeReactFlow


### PR DESCRIPTION
This should fix iPad issues with the edit page not quite fitting and scrolling off the bottom of the display.

Ref:

* https://github.com/tailwindlabs/tailwindcss/discussions/8216#discussioncomment-4621818

* https://web.dev/viewport-units/