### PR TITLE
fix: show global actions when there is no selection

### DIFF
--- a/src/Edit.tsx
+++ b/src/Edit.tsx
@@ -364,9 +364,11 @@ const AppNoError = ({
             }}
           />
         ) : (
-          <div className="p-10">
-            Click something on the canvas to see available actions!
-          </div>
+          <ActionsListNoSelection
+            onClickAddDef={() => setShowCreateDefModal(true)}
+            onClickAddTypeDef={() => setShowCreateTypeDefModal(true)}
+            level={level}
+          />
         )}
         {showCreateDefModal ? (
           <CreateDefModal
@@ -461,6 +463,32 @@ const ActionsListSelection = (p: {
   });
   const actions = queryRes.isSuccess ? queryRes.data : [];
   return <ActionPanel {...{ actions, ...p }} />;
+};
+
+const ActionsListNoSelection = (p: {
+  onClickAddDef: MouseEventHandler<HTMLButtonElement>;
+  onClickAddTypeDef: MouseEventHandler<HTMLButtonElement>;
+  level: Level;
+}) => {
+  return (
+    <ActionPanel
+      {...{
+        actions: [],
+        // Temporary hack, fix these up later.,
+        onAction: () => {
+          console.log("onAction called with no selection");
+        },
+        onInputAction: () => {
+          console.log("onInputAction called with no selection");
+        },
+        onRequestOpts: () => {
+          console.log("onRequestOpts called with no selection");
+          return Promise.resolve({ free: "FreeNone", opts: [] });
+        },
+        ...p,
+      }}
+    />
+  );
 };
 
 export default Edit;


### PR DESCRIPTION
When I removed the sidebar in
e3428ec1811fc94336d8fa0f416f896c7b215cd1, I didn't consider what happens when there's no selection: we don't render the action panel, but that's where the "add new def" and "add new type" buttons are now!

We now render just those 2 actions in the action panel when there's no selection. This has the nice side effect of getting rid of the not very helpful and hastily designed message that we used to display when this happens.

Note that the "fixes" are more like hacky workarounds. The action panel wasn't designed to be shown without a selection, so we pass some console logging `on*` handlers to catch any problems that might arise due to this change. We should refactor things to properly support this scenario, though.