### PR TITLE
chore: bump eval limit

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-41ee2a90cfd378a9fe054a18e9db7baaa1626207
+          image: ghcr.io/hackworthltd/primer-service-dev:git-8487cfab7b4bce6b9c26d001bd1a098db3d38360
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -1678,17 +1678,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1686418053,
-        "narHash": "sha256-K9kB4W3OJyw1p0L8DBgQZhgyoj/8R8JaVwEJbpRu1aQ=",
+        "lastModified": 1686488576,
+        "narHash": "sha256-MdUeK6In08YsDcybaZlr59pkDuh0hLoW5UTHFNG4pz4=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "41ee2a90cfd378a9fe054a18e9db7baaa1626207",
+        "rev": "8487cfab7b4bce6b9c26d001bd1a098db3d38360",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "41ee2a90cfd378a9fe054a18e9db7baaa1626207",
+        "rev": "8487cfab7b4bce6b9c26d001bd1a098db3d38360",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/41ee2a90cfd378a9fe054a18e9db7baaa1626207;
+    primer.url = github:hackworthltd/primer/8487cfab7b4bce6b9c26d001bd1a098db3d38360;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };

--- a/src/Edit.tsx
+++ b/src/Edit.tsx
@@ -230,7 +230,7 @@ const AppNoError = ({
     useEvalFull(
       p.sessionId,
       { qualifiedModule: p.module.modname, baseName: evalTarget || "" },
-      { stepLimit: 100 },
+      { stepLimit: 300 },
       { query: { enabled: !!evalTarget } }
     ),
     [p.module]


### PR DESCRIPTION
We bump the Primer pin (still running off
https://github.com/hackworthltd/primer/pull/1070, FYI) and bump the eval step limit to 300.