### PR TITLE
fix: invalidate session list upon successful session creation

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -6,10 +6,3 @@ export interface Account {
   id: string;
   avatarStyle: AvatarStyle;
 }
-
-// Placeholder type for our backend session type.
-export interface SessionMeta {
-  id: string;
-  name: string;
-  lastModified: Date;
-}

--- a/src/components/ChooseSession/index.tsx
+++ b/src/components/ChooseSession/index.tsx
@@ -1,7 +1,6 @@
 import type { MouseEventHandler } from "react";
 import { useState } from "react";
 import { useCookies } from "react-cookie";
-import type { SessionMeta } from "@/Types";
 import { exampleAccount, SessionsPage } from "@/components";
 import type {
   GetSessionListParams,
@@ -42,12 +41,6 @@ const ChooseSession = (): JSX.Element => {
   const { data } = useGetSessionList(params);
 
   const sessions: Session[] = data ? data.items : [];
-  const sessionsMeta: SessionMeta[] = sessions.map((session: Session) => ({
-    name: session.name,
-    id: session.id,
-    lastModified: session.lastModified,
-  }));
-
   const meta: PaginatedMeta = data
     ? data.meta
     : { totalItems: 0, pageSize: 1, thisPage: 1, firstPage: 1, lastPage: 1 };
@@ -82,7 +75,7 @@ const ChooseSession = (): JSX.Element => {
   return (
     <SessionsPage
       account={{ ...exampleAccount, id: cookies.id }}
-      sessions={sessionsMeta}
+      sessions={sessions}
       startIndex={startIndex}
       numItems={meta.pageSize}
       totalItems={meta.totalItems}

--- a/src/components/ChooseSession/index.tsx
+++ b/src/components/ChooseSession/index.tsx
@@ -2,12 +2,7 @@ import type { MouseEventHandler } from "react";
 import { useState } from "react";
 import { useCookies } from "react-cookie";
 import { exampleAccount, SessionsPage } from "@/components";
-import type {
-  GetSessionListParams,
-  PaginatedMeta,
-  Session,
-  Uuid,
-} from "@/primer-api";
+import type { PaginatedMeta, Session, Uuid } from "@/primer-api";
 import {
   useGetSessionList,
   useCreateSession,
@@ -24,21 +19,19 @@ const ChooseSession = (): JSX.Element => {
   const [page, setPage] = useState(1);
   const [pageSize] = useState(20);
   const [sessionNameFilter, setSessionNameFilter] = useState("");
+
   const queryClient = useQueryClient();
   const deleteSession = useDeleteSession({
     mutation: {
-      onSuccess: () => {
-        queryClient.invalidateQueries(getGetSessionListQueryKey());
-      },
+      onSuccess: () =>
+        queryClient.invalidateQueries(getGetSessionListQueryKey()),
     },
   });
-
-  const params: GetSessionListParams = {
-    page: page,
-    pageSize: pageSize,
+  const { data } = useGetSessionList({
+    page,
+    pageSize,
     nameLike: sessionNameFilter,
-  };
-  const { data } = useGetSessionList(params);
+  });
 
   const sessions: Session[] = data ? data.items : [];
   const meta: PaginatedMeta = data
@@ -63,7 +56,10 @@ const ChooseSession = (): JSX.Element => {
   const navigate = useNavigate();
   const newSession = useCreateSession({
     mutation: {
-      onSuccess: (newSessionID: Uuid) => navigate(`/sessions/${newSessionID}`),
+      onSuccess: (newSessionID: Uuid) => {
+        queryClient.invalidateQueries(getGetSessionListQueryKey());
+        navigate(`/sessions/${newSessionID}`);
+      },
     },
   });
 

--- a/src/components/SessionList/SessionList.stories.tsx
+++ b/src/components/SessionList/SessionList.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { exampleSessionsMeta } from "@/components/examples/sessions";
+import { exampleSessions } from "@/components/examples/sessions";
 
 import { SessionList } from "./";
 
@@ -18,5 +18,5 @@ const Template: ComponentStory<typeof SessionList> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  sessions: exampleSessionsMeta(),
+  sessions: exampleSessions(),
 };

--- a/src/components/SessionList/index.tsx
+++ b/src/components/SessionList/index.tsx
@@ -1,13 +1,13 @@
 import "@/index.css";
 
-import { SessionMeta } from "@/Types";
 import { SessionPreview } from "@/components";
+import type { Session } from "@/primer-api";
 
 export interface SessionListProps {
   /**
    * The list of session metadata.
    */
-  sessions: SessionMeta[];
+  sessions: Session[];
   onClickDelete: (id: string) => void;
 }
 

--- a/src/components/SessionPreview/SessionPreview.stories.tsx
+++ b/src/components/SessionPreview/SessionPreview.stories.tsx
@@ -18,25 +18,25 @@ const Template: ComponentStory<typeof SessionPreview> = (args) => (
 
 export const English = Template.bind({});
 English.args = {
-  session: examples.englishSessionMeta,
+  session: examples.englishSession,
 };
 
 export const Japanese = Template.bind({});
 Japanese.args = {
-  session: examples.japaneseSessionMeta,
+  session: examples.japaneseSession,
 };
 
 export const SimplifiedChinese = Template.bind({});
 SimplifiedChinese.args = {
-  session: examples.simplifiedChineseSessionMeta,
+  session: examples.simplifiedChineseSession,
 };
 
 export const Arabic = Template.bind({});
 Arabic.args = {
-  session: examples.arabicSessionMeta,
+  session: examples.arabicSession,
 };
 
 export const Emoji = Template.bind({});
 Emoji.args = {
-  session: examples.emojiSessionMeta,
+  session: examples.emojiSession,
 };

--- a/src/components/SessionPreview/index.tsx
+++ b/src/components/SessionPreview/index.tsx
@@ -1,14 +1,13 @@
 import "@/index.css";
 
 import { StarIcon, TrashIcon, UserPlusIcon } from "@heroicons/react/24/outline";
-
 import { Link } from "react-router-dom";
 
-import { SessionMeta } from "@/Types";
 import { BinaryTreePlaceholder } from "@/components";
+import type { Session } from "@/primer-api";
 
 export interface SessionPreviewProps {
-  session: SessionMeta;
+  session: Session;
   onClickDelete: () => void;
 }
 

--- a/src/components/SessionsPage/SessionsPage.stories.tsx
+++ b/src/components/SessionsPage/SessionsPage.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { SessionsPage } from "./";
-import { exampleSessionsMeta } from "@/components/examples/sessions";
+import { exampleSessions } from "@/components/examples/sessions";
 import { exampleAccount } from "@/components/examples/accounts";
 
 export default {
@@ -44,7 +44,7 @@ const Template: ComponentStory<typeof SessionsPage> = (args) => (
 export const Default = Template.bind({});
 Default.args = {
   account: exampleAccount,
-  sessions: exampleSessionsMeta(),
+  sessions: exampleSessions(),
   startIndex: 21,
   totalItems: 95,
 };

--- a/src/components/SessionsPage/index.tsx
+++ b/src/components/SessionsPage/index.tsx
@@ -7,8 +7,8 @@ import {
   SessionList,
   SessionNameModal,
 } from "@/components";
-import type { SessionMeta, Account } from "@/Types";
-import type { Uuid } from "@/primer-api";
+import type { Account } from "@/Types";
+import type { Session, Uuid } from "@/primer-api";
 
 import "@/index.css";
 
@@ -23,9 +23,9 @@ export interface SessionsPageProps {
   /**
    * The list of session metadata displayed on this page.
    *
-   * @type {SessionMeta[]}
+   * @type {Session[]}
    */
-  sessions: SessionMeta[];
+  sessions: Session[];
 
   /**
    * The event handler for the "New program" button.

--- a/src/components/examples/sessions.ts
+++ b/src/components/examples/sessions.ts
@@ -1,43 +1,44 @@
 import { v4 as uuidv4 } from "uuid";
-import type { SessionMeta } from "@/Types";
 
-export const englishSessionMeta: SessionMeta = {
+import type { Session } from "@/primer-api";
+
+export const englishSession: Session = {
   id: uuidv4(),
   name: "Example program",
   lastModified: new Date("2021-08-15T23:17:50.918Z"),
 };
 
-export const japaneseSessionMeta: SessionMeta = {
+export const japaneseSession: Session = {
   id: uuidv4(),
   name: "サンプルプログラム",
   lastModified: new Date("2021-08-07T10:12:03.332Z"),
 };
 
-export const simplifiedChineseSessionMeta: SessionMeta = {
+export const simplifiedChineseSession: Session = {
   id: uuidv4(),
   name: "示例程序",
   lastModified: new Date("2021-07-10T09:00:01.000Z"),
 };
 
-export const arabicSessionMeta: SessionMeta = {
+export const arabicSession: Session = {
   id: uuidv4(),
   name: "برنامج مثال",
   lastModified: new Date("2021-08-20T03:20:59.999Z"),
 };
 
-export const emojiSessionMeta: SessionMeta = {
+export const emojiSession: Session = {
   id: uuidv4(),
   name: "😄😂🤣🤗 🦊 🦈",
   lastModified: new Date("2021-07-23T11:53:13.730Z"),
 };
 
-export const exampleSessionsMeta = (): SessionMeta[] => {
+export const exampleSessions = (): Session[] => {
   return [
-    englishSessionMeta,
-    japaneseSessionMeta,
-    simplifiedChineseSessionMeta,
-    arabicSessionMeta,
-    emojiSessionMeta,
+    englishSession,
+    japaneseSession,
+    simplifiedChineseSession,
+    arabicSession,
+    emojiSession,
     {
       id: uuidv4(),
       name: "Map test",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,6 +27,6 @@ export { default as SimplePaginationBar } from "./SimplePaginationBar";
 export { default as Toolbar } from "./Toolbar";
 export { default as TreeReactFlow, TreeReactFlowOne } from "./TreeReactFlow";
 export { default as UIButton } from "./UIButton";
-export { exampleSessionsMeta } from "./examples/sessions";
+export { exampleSessions } from "./examples/sessions";
 export { exampleAccount } from "./examples/accounts";
 export { tree1, tree2, tree3, tree4, tree5 } from "./examples/trees";


### PR DESCRIPTION
This is the first in a series of cleanups of the `ChooseSession` and related components, which I plan to use as exemplars of how to make the frontend production-ready.