### PR TITLE
Bring node labels in-line

### DIFF
--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -35,11 +35,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Audit is disabled for now. See discussion at:
+      # https://github.com/hackworthltd/primer-app/pull/1005
+
       # Note: we only audit non-dev dependencies, because there are
       # nearly always dev dependency vulnerabilities, but they're very
       # unlikely to affect the production app.
-      - name: Audit
-        run: pnpm audit --prod
+      # - name: Audit
+      #   run: pnpm audit --prod
 
       - name: Build the frontend
         # This URL scheme for PR's is baked into other parts of the

--- a/src/components/Edit/index.tsx
+++ b/src/components/Edit/index.tsx
@@ -48,8 +48,10 @@ import {
 } from "@/primer-api";
 import {
   defaultTreeReactFlowProps,
+  inlineTreeReactFlowProps,
   ScrollToDef,
 } from "@/components/TreeReactFlow";
+import { Mode } from "../Toolbar";
 
 // hardcoded values (for now)
 const initialLevel: Level = "Expert";
@@ -198,6 +200,8 @@ const AppNoError = ({
   undoAvailable: boolean;
   redoAvailable: boolean;
 }): JSX.Element => {
+  const initialMode = "tree 1";
+  const [mode, setMode] = useState<Mode>(initialMode);
   const [level, setLevel] = useState<Level>(initialLevel);
   const toggleLevel = (): void => {
     switch (level) {
@@ -265,6 +269,17 @@ const AppNoError = ({
     .sort((a, b) => cmpName(a.name, b.name))
     .map((d) => d.name.baseName);
 
+  const treeProps = (() => {
+    switch (mode) {
+      case "text":
+        return defaultTreeReactFlowProps;
+      case "tree 1":
+        return defaultTreeReactFlowProps;
+      case "tree 2":
+        return inlineTreeReactFlowProps;
+    }
+  })();
+
   return (
     <div className="grid h-[100dvh] grid-cols-[auto_20rem]">
       <div className="relative h-full">
@@ -272,7 +287,7 @@ const AppNoError = ({
           <TreeReactFlow
             scrollToDefRef={scrollToDefRef}
             scrollToTypeDefRef={scrollToTypeDefRef}
-            {...defaultTreeReactFlowProps}
+            {...treeProps}
             {...(selection && { selection })}
             onNodeClick={(_e, sel) => sel && setSelection(sel)}
             defs={p.module.defs}
@@ -286,9 +301,7 @@ const AppNoError = ({
 
             <div className="absolute bottom-4 right-4 z-30">
               <Toolbar
-                onModeChange={() => {
-                  console.log("Toggle mode");
-                }}
+                onModeChange={setMode}
                 level={level}
                 onLevelChange={toggleLevel}
                 undoAvailable={p.undoAvailable}
@@ -307,7 +320,7 @@ const AppNoError = ({
                     })
                     .then(p.setProg);
                 }}
-                initialMode="tree"
+                initialMode={mode}
               />
             </div>
 
@@ -324,6 +337,7 @@ const AppNoError = ({
               defs={defs}
               initialEvalDef={evalTarget}
               typeOrKind={p.selectionTypeOrKind}
+              extraTreeProps={treeProps}
             />
           </TreeReactFlow>
         </ReactFlowProvider>

--- a/src/components/EvalFull/index.tsx
+++ b/src/components/EvalFull/index.tsx
@@ -2,7 +2,10 @@ import { useState } from "react";
 import { NodeChange, ReactFlowProvider, useReactFlow } from "reactflow";
 import { EvalFullResp, GlobalName, Level } from "@/primer-api";
 import { SelectMenu, TreeReactFlowOne } from "@/components";
-import { defaultTreeReactFlowProps } from "../TreeReactFlow";
+import {
+  TreeReactFlowOneProps,
+  defaultTreeReactFlowProps,
+} from "../TreeReactFlow";
 
 export type EvalFullProps = {
   moduleName: string[];
@@ -13,12 +16,14 @@ export type EvalFullProps = {
   level: Level;
   defs: string[];
   initialEvalDef: string | undefined;
+  extraTreeProps: Partial<TreeReactFlowOneProps>;
 };
 
 const Evaluated = (p: {
   defName: GlobalName;
   evaluated?: EvalFullResp;
   level: Level;
+  extraTreeProps: Partial<TreeReactFlowOneProps>;
 }) => {
   const padding = 1.0;
   const { fitView } = useReactFlow();
@@ -34,6 +39,7 @@ const Evaluated = (p: {
       zoomBarProps={{ padding }}
       onNodesChange={onNodesChange}
       fitViewOptions={{ padding }}
+      {...p.extraTreeProps}
     />
   );
 };
@@ -47,6 +53,7 @@ export const EvalFull = ({
   moduleName,
   level,
   initialEvalDef,
+  extraTreeProps,
 }: EvalFullProps): JSX.Element => {
   const [evalDef, setEvalDef0] = useState(initialEvalDef ?? disableEval);
   const setEvalDef = (e: string) => {
@@ -73,6 +80,7 @@ export const EvalFull = ({
                 defName={{ qualifiedModule: moduleName, baseName: evalDef }}
                 {...(evalFull.result ? { evaluated: evalFull.result } : {})}
                 level={level}
+                extraTreeProps={extraTreeProps}
               />
             </ReactFlowProvider>
           </div>

--- a/src/components/SelectionInfo/index.tsx
+++ b/src/components/SelectionInfo/index.tsx
@@ -1,14 +1,22 @@
 import { NodeChange, ReactFlowProvider, useReactFlow } from "reactflow";
 import { Level, TypeOrKind } from "@/primer-api";
 import { TreeReactFlowOne } from "@/components";
-import { defaultTreeReactFlowProps } from "../TreeReactFlow";
+import {
+  TreeReactFlowOneProps,
+  defaultTreeReactFlowProps,
+} from "../TreeReactFlow";
 
 export type SelectionInfoProps = {
   typeOrKind: TypeOrKind | undefined;
   level: Level;
+  extraTreeProps: Partial<TreeReactFlowOneProps>;
 };
 
-const TypeOrKindTree = (p: { typeOrKind: TypeOrKind; level: Level }) => {
+const TypeOrKindTree = (p: {
+  typeOrKind: TypeOrKind;
+  level: Level;
+  extraTreeProps: Partial<TreeReactFlowOneProps>;
+}) => {
   const padding = 1.0;
   const { fitView } = useReactFlow();
   const onNodesChange = (_: NodeChange[]) => {
@@ -23,6 +31,7 @@ const TypeOrKindTree = (p: { typeOrKind: TypeOrKind; level: Level }) => {
       zoomBarProps={{ padding }}
       onNodesChange={onNodesChange}
       fitViewOptions={{ padding }}
+      {...p.extraTreeProps}
     />
   );
 };
@@ -30,6 +39,7 @@ const TypeOrKindTree = (p: { typeOrKind: TypeOrKind; level: Level }) => {
 export const SelectionInfo = ({
   typeOrKind,
   level,
+  extraTreeProps,
 }: SelectionInfoProps): JSX.Element => {
   return (
     <div className="flex h-full flex-col overflow-auto">
@@ -40,7 +50,11 @@ export const SelectionInfo = ({
           </div>
           <div className="grow">
             <ReactFlowProvider>
-              <TypeOrKindTree typeOrKind={typeOrKind} level={level} />
+              <TypeOrKindTree
+                typeOrKind={typeOrKind}
+                level={level}
+                extraTreeProps={extraTreeProps}
+              />
             </ReactFlowProvider>
           </div>
         </>

--- a/src/components/Toolbar/Toolbar.stories.tsx
+++ b/src/components/Toolbar/Toolbar.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Toolbar>;
 
 export const Default: Story = {
   args: {
-    initialMode: "tree",
+    initialMode: "tree 1",
     level: "Expert",
     redoAvailable: true,
     undoAvailable: true,

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -23,7 +23,7 @@ export type ToolbarProps = {
   undoAvailable: boolean;
   onClickUndo: MouseEventHandler<HTMLButtonElement>;
 };
-export type Mode = "text" | "tree";
+export type Mode = "text" | "tree 1" | "tree 2";
 
 const iconClasses = "stroke-[2] p-1";
 const heavyIconClasses = "w-7 stroke-[3] p-1";
@@ -32,7 +32,8 @@ const modeSvg = (m: Mode) => {
   switch (m) {
     case "text":
       return <CodeBracketIcon className={iconClasses} />;
-    case "tree":
+    case "tree 1":
+    case "tree 2":
       return <ShareIcon className={classNames(iconClasses, "rotate-90")} />;
   }
 };
@@ -40,8 +41,10 @@ const modeSvg = (m: Mode) => {
 const nextMode = (m: Mode): Mode => {
   switch (m) {
     case "text":
-      return "tree";
-    case "tree":
+      return "tree 1";
+    case "tree 1":
+      return "tree 2";
+    case "tree 2":
       return "text";
   }
 };

--- a/src/components/TreeReactFlow/Flavor.ts
+++ b/src/components/TreeReactFlow/Flavor.ts
@@ -592,7 +592,7 @@ export const sortContentClasses = (s: "term" | "type" | "kind"): string => {
     case "type":
       return "";
     case "kind":
-      // This keeps the content fixed once the whole node is rotated. See `typeOrTermClasses`.
+      // This keeps the content fixed once the whole node is rotated. See `sortClasses`.
       return "-rotate-45";
   }
 };

--- a/src/components/TreeReactFlow/Flavor.ts
+++ b/src/components/TreeReactFlow/Flavor.ts
@@ -281,7 +281,10 @@ export const flavorContentClasses = (
     })()
   );
 
-export const flavorLabelClasses = (flavor: NodeFlavor): string => {
+export const flavorLabelClasses = (flavor: NodeFlavor): string =>
+  classNames(
+    sortLabelClasses(flavorSort(flavor)),
+    (() => {
   switch (flavor) {
     case "Hole":
       return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
@@ -348,7 +351,8 @@ export const flavorLabelClasses = (flavor: NodeFlavor): string => {
     case "PatternBind":
       return "bg-blue-quaternary border-blue-quaternary text-white-primary";
   }
-};
+    })()
+  );
 
 export const flavorEdgeClasses = (flavor: NodeFlavor): string => {
   switch (flavor) {
@@ -577,7 +581,7 @@ export const flavorSort = (flavor: NodeFlavor): "term" | "type" | "kind" => {
 export const sortClasses = (s: "term" | "type" | "kind"): string => {
   switch (s) {
     case "term":
-      return "rounded-3xl";
+      return classNames("rounded-3xl");
     case "type":
       return "";
     case "kind":
@@ -585,10 +589,22 @@ export const sortClasses = (s: "term" | "type" | "kind"): string => {
   }
 };
 
+export const sortLabelClasses = (s: "term" | "type" | "kind"): string => {
+  switch (s) {
+    case "term":
+      return "rounded-3xl";
+    case "type":
+      return "";
+    case "kind":
+      return "";
+  }
+};
+
 export const sortContentClasses = (s: "term" | "type" | "kind"): string => {
   switch (s) {
     case "term":
-      return "";
+      // This makes the content look more centered, given the rounded ends. See `sortClasses`.
+      return "right-1";
     case "type":
       return "";
     case "kind":

--- a/src/components/TreeReactFlow/Flavor.ts
+++ b/src/components/TreeReactFlow/Flavor.ts
@@ -285,72 +285,72 @@ export const flavorLabelClasses = (flavor: NodeFlavor): string =>
   classNames(
     sortLabelClasses(flavorSort(flavor)),
     (() => {
-  switch (flavor) {
-    case "Hole":
-      return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
-    case "EmptyHole":
-      return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
-    case "Ann":
-      return "font-code bg-black-primary border-black-primary text-white-primary";
-    case "App":
-      return "font-code bg-blue-tertiary border-blue-tertiary text-white-primary";
-    case "APP":
-      return "font-code bg-blue-tertiary border-blue-tertiary text-white-primary";
-    case "Con":
-      return "bg-green-primary border-green-primary text-white-primary";
-    case "Lam":
-      return "font-code bg-blue-primary border-blue-primary text-white-primary";
-    case "LAM":
-      return "font-code bg-blue-secondary border-blue-secondary text-white-primary";
-    case "GlobalVar":
-      return "bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "KHole":
-      return "italic font-code bg-grey-tertiary border-grey-tertiary text-white-primary";
-    case "KType":
-      return "font-code bg-grey-tertiary bg-grey-tertiary text-white-primary";
-    case "KFun":
-      return "font-code bg-grey-tertiary bg-grey-tertiary text-white-primary";
-    case "LocalVar":
-      return "bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "Let":
-      return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "LetType":
-      return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "Letrec":
-      return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "Case":
-      return "font-code bg-yellow-primary border-yellow-primary text-white-primary";
-    case "CaseWith": // Special case: we hide this label.
-      return "hidden font-code bg-yellow-primary border-yellow-primary text-white-primary";
-    case "PrimCon":
-      return "bg-green-primary border-green-primary text-white-primary";
-    case "TEmptyHole":
-      return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
-    case "THole":
-      return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
-    case "TCon":
-      return "bg-green-primary border-green-primary text-white-primary";
-    case "TFun":
-      return "font-code bg-blue-primary border-blue-primary text-white-primary";
-    case "TVar":
-      return "bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "TApp":
-      return "font-code bg-blue-tertiary border-blue-tertiary text-white-primary";
-    case "TForall":
-      return "font-code bg-blue-secondary border-blue-secondary text-white-primary";
-    case "TLet":
-      return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
-    case "Pattern":
-      return "";
-    case "PatternCon":
-      return "bg-green-primary border-green-primary text-white-primary";
-    case "PrimPattern":
-      return "bg-green-primary border-green-primary text-white-primary";
-    case "PatternWildcard":
-      return "hidden";
-    case "PatternBind":
-      return "bg-blue-quaternary border-blue-quaternary text-white-primary";
-  }
+      switch (flavor) {
+        case "Hole":
+          return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
+        case "EmptyHole":
+          return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
+        case "Ann":
+          return "font-code bg-black-primary border-black-primary text-white-primary";
+        case "App":
+          return "font-code bg-blue-tertiary border-blue-tertiary text-white-primary";
+        case "APP":
+          return "font-code bg-blue-tertiary border-blue-tertiary text-white-primary";
+        case "Con":
+          return "bg-green-primary border-green-primary text-white-primary";
+        case "Lam":
+          return "font-code bg-blue-primary border-blue-primary text-white-primary";
+        case "LAM":
+          return "font-code bg-blue-secondary border-blue-secondary text-white-primary";
+        case "GlobalVar":
+          return "bg-blue-quaternary border-blue-quaternary text-white-primary";
+        case "KHole":
+          return "italic font-code bg-grey-tertiary border-grey-tertiary text-white-primary";
+        case "KType":
+          return "font-code bg-grey-tertiary bg-grey-tertiary text-white-primary";
+        case "KFun":
+          return "font-code bg-grey-tertiary bg-grey-tertiary text-white-primary";
+        case "LocalVar":
+          return "bg-blue-quaternary border-blue-quaternary text-white-primary";
+        case "Let":
+          return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
+        case "LetType":
+          return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
+        case "Letrec":
+          return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
+        case "Case":
+          return "font-code bg-yellow-primary border-yellow-primary text-white-primary";
+        case "CaseWith": // Special case: we hide this label.
+          return "hidden font-code bg-yellow-primary border-yellow-primary text-white-primary";
+        case "PrimCon":
+          return "bg-green-primary border-green-primary text-white-primary";
+        case "TEmptyHole":
+          return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
+        case "THole":
+          return "italic font-code bg-red-tertiary border-red-tertiary text-white-primary";
+        case "TCon":
+          return "bg-green-primary border-green-primary text-white-primary";
+        case "TFun":
+          return "font-code bg-blue-primary border-blue-primary text-white-primary";
+        case "TVar":
+          return "bg-blue-quaternary border-blue-quaternary text-white-primary";
+        case "TApp":
+          return "font-code bg-blue-tertiary border-blue-tertiary text-white-primary";
+        case "TForall":
+          return "font-code bg-blue-secondary border-blue-secondary text-white-primary";
+        case "TLet":
+          return "font-code bg-blue-quaternary border-blue-quaternary text-white-primary";
+        case "Pattern":
+          return "";
+        case "PatternCon":
+          return "bg-green-primary border-green-primary text-white-primary";
+        case "PrimPattern":
+          return "bg-green-primary border-green-primary text-white-primary";
+        case "PatternWildcard":
+          return "hidden";
+        case "PatternBind":
+          return "bg-blue-quaternary border-blue-quaternary text-white-primary";
+      }
     })()
   );
 

--- a/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
+++ b/src/components/TreeReactFlow/TreeReactFlow.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import {
   defaultTreeReactFlowProps,
+  inlineTreeReactFlowProps,
   TreeReactFlow,
   TreeReactFlowProps,
 } from "./";
@@ -288,6 +289,23 @@ export const OddAndEvenMiscStyles: ComponentStory<typeof TreeReactFlow> = (
   treeSized({
     ...args,
     defs: oddEvenDefsMiscStyles,
+    typeDefs: [],
+    selection: {
+      tag: "SelectionDef",
+      contents: { def: def5.name, node: { nodeType: "BodyNode", meta: 5 } },
+    },
+  });
+export const OddAndEvenInline: ComponentStory<typeof TreeReactFlow> = (
+  args: TreeReactFlowProps
+) =>
+  treeSized({
+    ...inlineTreeReactFlowProps,
+    ...args,
+    defs: oddEvenTrees.map(([baseName, term]) => ({
+      name: { qualifiedModule: [], baseName },
+      term,
+      type_: emptyTypeTree(baseName),
+    })),
     typeDefs: [],
     selection: {
       tag: "SelectionDef",

--- a/src/components/TreeReactFlow/Types.ts
+++ b/src/components/TreeReactFlow/Types.ts
@@ -195,6 +195,7 @@ export type PrimerCommonNodeProps = {
   width: number;
   height: number;
   selected: boolean;
+  style: "inline" | "corner";
 };
 
 /** Our edge type. Much like `PrimerNode`, `PrimerEdge` extends ReactFlow's `Edge`.

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -188,15 +188,15 @@ const nodeTypes = {
                 "ring-4 ring-offset-4": data.selected,
                 "hover:ring-opacity-50": !data.selected,
               },
-              "grid grid-cols-[2rem_auto] border-4 overflow-hidden text-grey-tertiary",
+              "grid grid-cols-[2rem_auto] gap-1 border-4 text-grey-tertiary",
               flavorClasses(data.flavor)
             ),
             label: classNames(
-              "flex items-center justify-center pr-1 text-sm xl:text-base",
+              "flex items-center justify-center text-sm xl:text-base -m-1 mr-0",
               flavorLabelClasses(data.flavor)
             ),
             contents: classNames(
-              "truncate self-center justify-self-center px-1 font-code text-sm xl:text-base max-w-full",
+              "truncate self-center justify-self-center font-code text-sm xl:text-base max-w-full relative",
               flavorContentClasses(data.flavor)
             ),
           };


### PR DESCRIPTION
At a recent in-person meeting, @dhess mentioned wanting to move labels to the left, and after thinking about it I said I'd like to try a bigger change, with labels brought down to the height of the main node contents. This is a mock-up of that change.

Pros:

- Reads nicely (more text-like) for `λ` and `∀` nodes.
- Allows us to make better use of space on the canvas, since the more uniform shape of nodes means we don't need to worry about labels overlapping with edges or other nodes.
- I personally just much prefer it on a base aesthetic level - it feels cleaner.

Still to do:

- [ ] Consider rendering of beginner-mode syntax nodes.
  - Revisiting this a few weeks later, I'm not totally sure what I considered the problem to be. I guess it's that the label and contents blur together due to both having solid backgrounds? If so, I don't think it's a major issue.
- [x] Fix the sometimes-visible gaps (anti-aliasing?) between labels and the node border.
  - ~~I really don't know how to fix this. And I don't want to sink any more time in to it when this style is just an experiment which we might not keep around.~~
- [x] Flesh out commit messages.
- Stuff that's related, but can be tackled separately:
  - Revisit our set of labels, e.g. `Var` and `V`, especially given our terminology discussions.
  - Be consistent: show labels on all type def nodes, and definition name nodes.
