### PR TITLE
chore(nix): switch to `treefmt`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1375,7 +1375,8 @@
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_2",
-        "primer": "primer"
+        "primer": "primer",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "stackage": {
@@ -1451,6 +1452,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1690874496,
+        "narHash": "sha256-qYZJVAfilFbUL6U+euMjKLXUADueMNQBqwihpNzTbDU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "fab56c8ce88f593300cd8c7351c9f97d10c333c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,9 @@
     pre-commit-hooks-nix.url = github:cachix/pre-commit-hooks.nix;
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
 
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
     primer.url = github:hackworthltd/primer/ff6c255185a3085ad9ce1e6970ada0776c2c2f37;
@@ -50,6 +53,7 @@
 
       imports = [
         inputs.pre-commit-hooks-nix.flakeModule
+        inputs.treefmt-nix.flakeModule
       ];
 
       systems = [ "x86_64-linux" "aarch64-darwin" ];
@@ -86,19 +90,9 @@
             settings = {
               src = ./.;
               hooks = {
-                prettier.enable = true;
-                nixpkgs-fmt.enable = true;
+                treefmt.enable = true;
                 actionlint.enable = true;
               };
-
-              excludes = [
-                "CONTRIBUTING.md"
-                "DCO.md"
-                "README.md"
-                "docs"
-                "package.json"
-                "pnpm-lock.yaml"
-              ];
             };
           };
 
@@ -124,9 +118,29 @@
               inherit bump-primer;
             });
 
+          treefmt.config = {
+            projectRootFile = "flake.nix";
+            programs = {
+              prettier.enable = true;
+              nixpkgs-fmt.enable = true;
+            };
+            settings.formatter.prettier = {
+              excludes = [
+                "CONTRIBUTING.md"
+                "DCO.md"
+                "README.md"
+                "docs"
+                "package.json"
+                "pnpm-lock.yaml"
+              ];
+            };
+          };
+
           devShells.default = pkgs.mkShell {
+            inputsFrom = [
+              config.treefmt.build.devShell
+            ];
             buildInputs = (with pkgs; [
-              nixpkgs-fmt
               nodejs_18
               nodejs_18.pkgs.pnpm
               rnix-lsp


### PR DESCRIPTION
We can now run `nix fmt` in the Nix shell and format all source files at once, regardless of the formatter needed, and quickly (once cached).