### PR TITLE
Add option to hide non-syntax labels in expert mode 

### DIFF
--- a/src/components/TreeReactFlow/Flavor.ts
+++ b/src/components/TreeReactFlow/Flavor.ts
@@ -603,8 +603,7 @@ export const sortLabelClasses = (s: "term" | "type" | "kind"): string => {
 export const sortContentClasses = (s: "term" | "type" | "kind"): string => {
   switch (s) {
     case "term":
-      // This makes the content look more centered, given the rounded ends. See `sortClasses`.
-      return "right-1";
+      return "";
     case "type":
       return "";
     case "kind":

--- a/src/components/TreeReactFlow/Flavor.ts
+++ b/src/components/TreeReactFlow/Flavor.ts
@@ -492,6 +492,31 @@ export const flavorLabel = (flavor: NodeFlavor): string => {
   }
 };
 
+/** This is a slightly shaky concept, but essentially it comes down to whether labels can be omitted
+ * without destroying the readability of the program.
+ * In other words, would we show this flavor's label in text mode?
+ */
+export const flavorIsSyntax = (flavor: NodeFlavorTextBody): boolean => {
+  switch (flavor) {
+    case "Lam":
+    case "LAM":
+    case "Let":
+    case "LetType":
+    case "Letrec":
+    case "TForall":
+    case "TLet":
+      return true;
+    case "Con":
+    case "GlobalVar":
+    case "LocalVar":
+    case "TCon":
+    case "TVar":
+    case "PatternCon":
+    case "PatternBind":
+      return false;
+  }
+};
+
 export const noBodyFlavorContents = (flavor: NodeFlavorNoBody): string => {
   switch (flavor) {
     case "Ann":

--- a/src/components/TreeReactFlow/Types.ts
+++ b/src/components/TreeReactFlow/Types.ts
@@ -158,7 +158,7 @@ export type NodeData =
 /** Node properties. */
 export type PrimerNodeProps = {
   nodeData: NodeData;
-  syntax: boolean;
+  centerLabel: boolean;
   flavor: NodeFlavorTextBody | NodeFlavorPrimBody | NodeFlavorNoBody;
   contents: string;
 };

--- a/src/components/TreeReactFlow/Types.ts
+++ b/src/components/TreeReactFlow/Types.ts
@@ -161,6 +161,7 @@ export type PrimerNodeProps = {
   centerLabel: boolean;
   flavor: NodeFlavorTextBody | NodeFlavorPrimBody | NodeFlavorNoBody;
   contents: string;
+  hideLabel: boolean;
 };
 
 /** Properties for a simple node. */

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -189,15 +189,15 @@ const nodeTypes = {
                 "ring-4 ring-offset-4": data.selected,
                 "hover:ring-opacity-50": !data.selected,
               },
-              "grid grid-cols-[2rem_auto] gap-1.5 border-4 text-grey-tertiary",
+              "flex gap-1.5 border-4 text-grey-tertiary",
               flavorClasses(data.flavor)
             ),
             label: classNames(
-              "flex items-center justify-center text-sm xl:text-base -m-1 mr-0",
+              "w-9 shrink-0 flex items-center justify-center text-sm xl:text-base -m-1 mr-0",
               flavorLabelClasses(data.flavor)
             ),
             contents: classNames(
-              "truncate self-center justify-self-center px-1 font-code text-sm xl:text-base max-w-full relative",
+              "overflow-hidden grow flex self-center justify-center px-1 font-code text-sm xl:text-base",
               flavorContentClasses(data.flavor),
               // This makes the content look more centered, given the rounded ends (see `sortClasses`).
               flavorSort(data.flavor) == "term" ? "relative right-1" : ""
@@ -218,7 +218,9 @@ const nodeTypes = {
           className={classes.root}
         >
           <div className={classes.label}>{flavorLabel(data.flavor)}</div>
-          <div className={classes.contents}>{data.contents}</div>
+          <div className={classes.contents}>
+            <div className="truncate">{data.contents}</div>
+          </div>
         </div>
         {handle("source", Position.Bottom)}
         {handle("source", Position.Right)}

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -58,6 +58,7 @@ import {
   flavorClasses,
   flavorContentClasses,
   flavorEdgeClasses,
+  flavorIsSyntax,
   flavorLabel,
   flavorLabelClasses,
   flavorSort,
@@ -200,7 +201,9 @@ const nodeTypes = {
               "overflow-hidden grow flex self-center justify-center px-1 font-code text-sm xl:text-base",
               flavorContentClasses(data.flavor),
               // This makes the content look more centered, given the rounded ends (see `sortClasses`).
-              flavorSort(data.flavor) == "term" ? "relative right-1" : ""
+              flavorSort(data.flavor) == "term" && !data.hideLabel
+                ? "relative right-1"
+                : ""
             ),
           };
       }
@@ -217,9 +220,13 @@ const nodeTypes = {
           }}
           className={classes.root}
         >
-          <div className={classes.label} style={{ width: data.height }}>
-            {flavorLabel(data.flavor)}
-          </div>
+          {data.hideLabel ? (
+            <></>
+          ) : (
+            <div className={classes.label} style={{ width: data.height }}>
+              {flavorLabel(data.flavor)}
+            </div>
+          )}
           <div className={classes.contents}>
             <div className="truncate">{data.contents}</div>
           </div>
@@ -555,6 +562,7 @@ const makePrimerNode = async (
       p.selection
     );
   const id = node.nodeId;
+  const hideLabels = p.level == "Expert" && false;
   const common = {
     width: p.nodeWidth,
     height: p.nodeHeight,
@@ -592,6 +600,7 @@ const makePrimerNode = async (
             flavor,
             contents,
             centerLabel: false,
+            hideLabel: hideLabels,
             ...common,
           },
           zIndex,
@@ -607,6 +616,7 @@ const makePrimerNode = async (
     }
     case "TextBody": {
       const { fst: flavor, snd: name } = node.body.contents;
+      const hideLabel = hideLabels && !flavorIsSyntax(flavor);
       return [
         {
           id,
@@ -615,9 +625,12 @@ const makePrimerNode = async (
             flavor,
             contents: name.baseName,
             centerLabel: false,
+            hideLabel,
             ...common,
             width:
-              p.style == "inline" ? common.width + common.height : common.width,
+              p.style == "inline" && !hideLabel
+                ? common.width + common.height
+                : common.width,
           },
           zIndex,
         },
@@ -646,6 +659,7 @@ const makePrimerNode = async (
               flavor,
               contents: noBodyFlavorContents(node.body.contents),
               centerLabel: node.children >= 2,
+              hideLabel: hideLabels,
               ...common,
               // TODO This is necessary to ensure that all syntax labels fit.
               // It can be removed when we have dynamic node sizes.

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -60,6 +60,7 @@ import {
   flavorEdgeClasses,
   flavorLabel,
   flavorLabelClasses,
+  flavorSort,
   noBodyFlavorContents,
   sortClasses,
 } from "./Flavor";
@@ -197,7 +198,9 @@ const nodeTypes = {
             ),
             contents: classNames(
               "truncate self-center justify-self-center px-1 font-code text-sm xl:text-base max-w-full relative",
-              flavorContentClasses(data.flavor)
+              flavorContentClasses(data.flavor),
+              // This makes the content look more centered, given the rounded ends (see `sortClasses`).
+              flavorSort(data.flavor) == "term" ? "relative right-1" : ""
             ),
           };
       }

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -132,11 +132,11 @@ export const defaultTreeReactFlowProps: Pick<
   treePadding: 100,
   nodeWidth: 80,
   nodeHeight: 35,
-  boxPadding: 50,
+  boxPadding: 55,
   defParams: { nameNodeMultipliers: { width: 3, height: 2 } },
   layout: {
     type: WasmLayoutType.Tidy,
-    margins: { child: 25, sibling: 18 },
+    margins: { child: 28, sibling: 18 },
   },
 };
 export const inlineTreeReactFlowProps: typeof defaultTreeReactFlowProps = {
@@ -174,7 +174,7 @@ const nodeTypes = {
             ),
             label: classNames(
               "flex justify-center z-20 p-1 absolute rounded-full text-sm xl:text-base",
-              data.centerLabel ? "-top-4" : "-left-2 -top-4",
+              data.centerLabel ? "-top-4" : "-left-2 -top-5",
               flavorLabelClasses(data.flavor)
             ),
             contents: classNames(

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -141,7 +141,7 @@ export const defaultTreeReactFlowProps: Pick<
 export const inlineTreeReactFlowProps: typeof defaultTreeReactFlowProps = {
   ...defaultTreeReactFlowProps,
   style: "inline",
-  nodeWidth: 100,
+  boxPadding: 35,
   layout: {
     ...defaultTreeReactFlowProps.layout,
     margins: { child: 15, sibling: 12 },
@@ -188,7 +188,7 @@ const nodeTypes = {
                 "ring-4 ring-offset-4": data.selected,
                 "hover:ring-opacity-50": !data.selected,
               },
-              "grid grid-cols-[2rem_auto] gap-1 border-4 text-grey-tertiary",
+              "grid grid-cols-[2rem_auto] gap-1.5 border-4 text-grey-tertiary",
               flavorClasses(data.flavor)
             ),
             label: classNames(
@@ -196,7 +196,7 @@ const nodeTypes = {
               flavorLabelClasses(data.flavor)
             ),
             contents: classNames(
-              "truncate self-center justify-self-center font-code text-sm xl:text-base max-w-full relative",
+              "truncate self-center justify-self-center px-1 font-code text-sm xl:text-base max-w-full relative",
               flavorContentClasses(data.flavor)
             ),
           };
@@ -609,6 +609,8 @@ const makePrimerNode = async (
             contents: name.baseName,
             syntax: false,
             ...common,
+            width:
+              p.style == "inline" ? common.width + common.height : common.width,
           },
           zIndex,
         },

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -173,7 +173,7 @@ const nodeTypes = {
               flavorClasses(data.flavor)
             ),
             label: classNames(
-              "z-20 p-1 absolute rounded-full text-sm xl:text-base",
+              "flex justify-center z-20 p-1 absolute rounded-full text-sm xl:text-base",
               data.centerLabel ? "-top-4" : "-left-2 -top-4",
               flavorLabelClasses(data.flavor)
             ),
@@ -193,7 +193,7 @@ const nodeTypes = {
               flavorClasses(data.flavor)
             ),
             label: classNames(
-              "w-9 shrink-0 flex items-center justify-center text-sm xl:text-base -m-1 mr-0",
+              "shrink-0 flex items-center justify-center text-sm xl:text-base -m-1 mr-0",
               flavorLabelClasses(data.flavor)
             ),
             contents: classNames(
@@ -217,7 +217,9 @@ const nodeTypes = {
           }}
           className={classes.root}
         >
-          <div className={classes.label}>{flavorLabel(data.flavor)}</div>
+          <div className={classes.label} style={{ width: data.height }}>
+            {flavorLabel(data.flavor)}
+          </div>
           <div className={classes.contents}>
             <div className="truncate">{data.contents}</div>
           </div>

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -174,7 +174,7 @@ const nodeTypes = {
             ),
             label: classNames(
               "z-20 p-1 absolute rounded-full text-sm xl:text-base",
-              data.syntax ? "-top-4" : "-left-2 -top-4",
+              data.centerLabel ? "-top-4" : "-left-2 -top-4",
               flavorLabelClasses(data.flavor)
             ),
             contents: classNames(
@@ -587,7 +587,7 @@ const makePrimerNode = async (
           data: {
             flavor,
             contents,
-            syntax: false,
+            centerLabel: false,
             ...common,
           },
           zIndex,
@@ -610,7 +610,7 @@ const makePrimerNode = async (
           data: {
             flavor,
             contents: name.baseName,
-            syntax: false,
+            centerLabel: false,
             ...common,
             width:
               p.style == "inline" ? common.width + common.height : common.width,
@@ -641,7 +641,7 @@ const makePrimerNode = async (
             data: {
               flavor,
               contents: noBodyFlavorContents(node.body.contents),
-              syntax: node.children >= 2,
+              centerLabel: node.children >= 2,
               ...common,
               // TODO This is necessary to ensure that all syntax labels fit.
               // It can be removed when we have dynamic node sizes.


### PR DESCRIPTION
This is sort of a follow-up to #1005, in terms of trying to make programs more text-mode-like and readable. @dhess mentioned this feature in https://github.com/hackworthltd/primer-app/pull/1005#issuecomment-1623383632, and I replied in https://github.com/hackworthltd/primer-app/pull/1005#issuecomment-1663895080 about how we really have two different sorts of labels. This PR hides those which are just "annotations".

If we don't like this change, I should separately merge the first few commits, as they are mostly clean-ups of #1005 and are generally a good thing regardless.