### PR TITLE
Add developer menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "deep-equal": "^2.2.2",
     "fp-ts": "^2.16.1",
     "history": "^5.3.0",
+    "re-resizable": "^6.9.9",
     "react": "^18.2.0",
     "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ dependencies:
   history:
     specifier: ^5.3.0
     version: 5.3.0
+  re-resizable:
+    specifier: ^6.9.9
+    version: 6.9.9(react-dom@18.2.0)(react@18.2.0)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -11435,6 +11438,16 @@ packages:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
     dev: true
+
+  /re-resizable@6.9.9(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==}
+    peerDependencies:
+      react: ^16.13.1 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Resizable } from "re-resizable";
 import "@/index.css";
 
 import { ChooseSession, Edit, NoMatch } from "@/components";
+import { DevOptions } from "@/components/Edit";
 
 // This ensures that we don't unnecessarily load the tools in production.
 // https://tanstack.com/query/v4/docs/react/devtools#devtools-in-production
@@ -41,8 +42,10 @@ const App = (): JSX.Element => {
 
   const devToolsMinHeight = 250;
   const devToolsMaxHeight = 500;
-  const [showIDs, setShowIDs] = useState(false);
-  const [alwaysShowLabels, setAlwaysShowLabels] = useState(true);
+  const [devOpts, setDevOpts] = useState<DevOptions>({
+    showIDs: false,
+    alwaysShowLabels: true,
+  });
 
   useEffect(() => {
     if (!cookies.id) {
@@ -88,28 +91,7 @@ const App = (): JSX.Element => {
                     setIsOpen={setDevtoolsOpen}
                     onDragStart={(_) => {}}
                   />
-                  <div className="bg-blue-primary pl-1 text-white-primary">
-                    <div>
-                      <input
-                        type="checkbox"
-                        id="showIDs"
-                        onChange={(e) => setShowIDs(e.target.checked)}
-                        className="mr-1"
-                      />
-                      <label htmlFor="showIDs">show node IDs</label>
-                    </div>
-                    <div>
-                      <input
-                        type="checkbox"
-                        id="alwaysShowLabels"
-                        onChange={(e) => setAlwaysShowLabels(e.target.checked)}
-                        className="mr-1"
-                      />
-                      <label htmlFor="alwaysShowLabels">
-                        always show labels
-                      </label>
-                    </div>
-                  </div>
+                  <DevMenu opts={devOpts} set={setDevOpts} />
                 </Resizable>
               )}
             </Suspense>
@@ -118,10 +100,7 @@ const App = (): JSX.Element => {
             <Route path="/" element={<Navigate to="/sessions" />} />
             <Route path="/sessions">
               <Route index element={<ChooseSession />} />
-              <Route
-                path=":sessionId"
-                element={<Edit {...{ showIDs, alwaysShowLabels }} />}
-              />
+              <Route path=":sessionId" element={<Edit {...devOpts} />} />
             </Route>
             <Route path="*" element={<NoMatch />} />
           </Routes>
@@ -130,5 +109,32 @@ const App = (): JSX.Element => {
     </CookiesProvider>
   );
 };
+
+const DevMenu = (p: { opts: DevOptions; set: (opts: DevOptions) => void }) => (
+  <div className="bg-blue-primary pl-1 text-white-primary">
+    <div>
+      <input
+        type="checkbox"
+        id="showIDs"
+        checked={p.opts.showIDs}
+        onChange={(e) => p.set({ ...p.opts, showIDs: e.target.checked })}
+        className="mr-1"
+      />
+      <label htmlFor="showIDs">show node IDs</label>
+    </div>
+    <div>
+      <input
+        type="checkbox"
+        id="alwaysShowLabels"
+        checked={p.opts.alwaysShowLabels}
+        onChange={(e) =>
+          p.set({ ...p.opts, alwaysShowLabels: e.target.checked })
+        }
+        className="mr-1"
+      />
+      <label htmlFor="alwaysShowLabels">always show labels</label>
+    </div>
+  </div>
+);
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ const App = (): JSX.Element => {
   const devToolsMaxHeight = 500;
   const [devOpts, setDevOpts] = useState<DevOptions>({
     showIDs: false,
+    inlineLabels: false,
     alwaysShowLabels: true,
   });
 
@@ -133,6 +134,16 @@ const DevMenu = (p: { opts: DevOptions; set: (opts: DevOptions) => void }) => (
         className="mr-1"
       />
       <label htmlFor="alwaysShowLabels">always show labels</label>
+    </div>
+    <div>
+      <input
+        type="checkbox"
+        id="inlineLabels"
+        checked={p.opts.inlineLabels}
+        onChange={(e) => p.set({ ...p.opts, inlineLabels: e.target.checked })}
+        className="mr-1"
+      />
+      <label htmlFor="inlineLabels">inline labels</label>
     </div>
   </div>
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,8 @@ const App = (): JSX.Element => {
 
   const devToolsMinHeight = 250;
   const devToolsMaxHeight = 500;
+  const [showIDs, setShowIDs] = useState(false);
+  const [alwaysShowLabels, setAlwaysShowLabels] = useState(true);
 
   useEffect(() => {
     if (!cookies.id) {
@@ -86,8 +88,28 @@ const App = (): JSX.Element => {
                     setIsOpen={setDevtoolsOpen}
                     onDragStart={(_) => {}}
                   />
-
-                  <div className="bg-blue-primary"></div>
+                  <div className="bg-blue-primary pl-1 text-white-primary">
+                    <div>
+                      <input
+                        type="checkbox"
+                        id="showIDs"
+                        onChange={(e) => setShowIDs(e.target.checked)}
+                        className="mr-1"
+                      />
+                      <label htmlFor="showIDs">show node IDs</label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        id="alwaysShowLabels"
+                        onChange={(e) => setAlwaysShowLabels(e.target.checked)}
+                        className="mr-1"
+                      />
+                      <label htmlFor="alwaysShowLabels">
+                        always show labels
+                      </label>
+                    </div>
+                  </div>
                 </Resizable>
               )}
             </Suspense>
@@ -96,7 +118,10 @@ const App = (): JSX.Element => {
             <Route path="/" element={<Navigate to="/sessions" />} />
             <Route path="/sessions">
               <Route index element={<ChooseSession />} />
-              <Route path=":sessionId" element={<Edit />} />
+              <Route
+                path=":sessionId"
+                element={<Edit {...{ showIDs, alwaysShowLabels }} />}
+              />
             </Route>
             <Route path="*" element={<NoMatch />} />
           </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const App = (): JSX.Element => {
           {enableDevtools && (
             <Suspense fallback={null}>
               <button
-                className="absolute right-0 z-20 p-4"
+                className="absolute right-0 z-50 p-4"
                 onClick={() => setDevtoolsOpen((old) => !old)}
               >
                 <WrenchScrewdriverIcon className="h-10 fill-grey-primary"></WrenchScrewdriverIcon>
@@ -82,12 +82,11 @@ const App = (): JSX.Element => {
                 <Resizable
                   enable={{ bottom: true }}
                   defaultSize={{ height: devToolsMinHeight, width: "100%" }}
-                  className="fixed z-10 grid grid-cols-[minmax(0,2fr)_1fr]"
+                  className="fixed grid grid-cols-[minmax(0,2fr)_1fr]"
                   minHeight={devToolsMinHeight}
                   maxHeight={devToolsMaxHeight}
                 >
                   <ReactQueryDevtoolsPanel
-                    className="z-20"
                     style={{ height: "inherit", maxHeight: devToolsMaxHeight }}
                     setIsOpen={setDevtoolsOpen}
                     onDragStart={(_) => {}}

--- a/src/components/Edit/index.tsx
+++ b/src/components/Edit/index.tsx
@@ -58,6 +58,7 @@ const initialLevel: Level = "Expert";
 
 export type DevOptions = {
   showIDs: boolean;
+  inlineLabels: boolean;
   alwaysShowLabels: boolean;
 };
 
@@ -217,7 +218,7 @@ const AppNoError = ({
   redoAvailable: boolean;
   devOpts: DevOptions;
 }): JSX.Element => {
-  const initialMode = "tree 1";
+  const initialMode = "tree";
   const [mode, setMode] = useState<Mode>(initialMode);
   const [level, setLevel] = useState<Level>(initialLevel);
   const toggleLevel = (): void => {
@@ -286,16 +287,9 @@ const AppNoError = ({
     .sort((a, b) => cmpName(a.name, b.name))
     .map((d) => d.name.baseName);
 
-  const treeProps = (() => {
-    switch (mode) {
-      case "text":
-        return defaultTreeReactFlowProps;
-      case "tree 1":
-        return defaultTreeReactFlowProps;
-      case "tree 2":
-        return inlineTreeReactFlowProps;
-    }
-  })();
+  const treeProps = p.devOpts.inlineLabels
+    ? inlineTreeReactFlowProps
+    : defaultTreeReactFlowProps;
 
   return (
     <div className="grid h-[100dvh] grid-cols-[auto_20rem]">

--- a/src/components/Edit/index.tsx
+++ b/src/components/Edit/index.tsx
@@ -56,7 +56,12 @@ import { Mode } from "../Toolbar";
 // hardcoded values (for now)
 const initialLevel: Level = "Expert";
 
-const Edit = (): JSX.Element => {
+export type DevOptions = {
+  showIDs: boolean;
+  alwaysShowLabels: boolean;
+};
+
+const Edit = (devOpts: DevOptions): JSX.Element => {
   const params = useParams();
   const sessionId = params["sessionId"];
 
@@ -88,10 +93,20 @@ const Edit = (): JSX.Element => {
   }
 
   // At this point, we have successfully received an initial program.
-  return <AppProg initialProg={queryRes.data} {...{ sessionId }}></AppProg>;
+  return (
+    <AppProg
+      initialProg={queryRes.data}
+      {...{ sessionId }}
+      devOpts={devOpts}
+    ></AppProg>
+  );
 };
 
-const AppProg = (p: { sessionId: string; initialProg: Prog }): JSX.Element => {
+const AppProg = (p: {
+  sessionId: string;
+  initialProg: Prog;
+  devOpts: DevOptions;
+}): JSX.Element => {
   const [prog, setProg0] = useState<Prog>(p.initialProg);
   const [selection, setSelection0] = useState<Selection | undefined>(
     prog.selection
@@ -140,6 +155,7 @@ const AppProg = (p: { sessionId: string; initialProg: Prog }): JSX.Element => {
       setProg={setProg}
       undoAvailable={prog.undoAvailable}
       redoAvailable={prog.redoAvailable}
+      devOpts={p.devOpts}
     />
   );
 };
@@ -199,6 +215,7 @@ const AppNoError = ({
   setProg: (p: Prog) => void;
   undoAvailable: boolean;
   redoAvailable: boolean;
+  devOpts: DevOptions;
 }): JSX.Element => {
   const initialMode = "tree 1";
   const [mode, setMode] = useState<Mode>(initialMode);
@@ -288,6 +305,8 @@ const AppNoError = ({
             scrollToDefRef={scrollToDefRef}
             scrollToTypeDefRef={scrollToTypeDefRef}
             {...treeProps}
+            showIDs={p.devOpts.showIDs}
+            alwaysShowLabels={p.devOpts.alwaysShowLabels}
             {...(selection && { selection })}
             onNodeClick={(_e, sel) => sel && setSelection(sel)}
             defs={p.module.defs}

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -23,7 +23,7 @@ export type ToolbarProps = {
   undoAvailable: boolean;
   onClickUndo: MouseEventHandler<HTMLButtonElement>;
 };
-export type Mode = "text" | "tree 1" | "tree 2";
+export type Mode = "text" | "tree";
 
 const iconClasses = "stroke-[2] p-1";
 const heavyIconClasses = "w-7 stroke-[3] p-1";
@@ -32,8 +32,7 @@ const modeSvg = (m: Mode) => {
   switch (m) {
     case "text":
       return <CodeBracketIcon className={iconClasses} />;
-    case "tree 1":
-    case "tree 2":
+    case "tree":
       return <ShareIcon className={classNames(iconClasses, "rotate-90")} />;
   }
 };
@@ -41,10 +40,8 @@ const modeSvg = (m: Mode) => {
 const nextMode = (m: Mode): Mode => {
   switch (m) {
     case "text":
-      return "tree 1";
-    case "tree 1":
-      return "tree 2";
-    case "tree 2":
+      return "tree";
+    case "tree":
       return "text";
   }
 };

--- a/src/components/TreeReactFlow/Types.ts
+++ b/src/components/TreeReactFlow/Types.ts
@@ -162,18 +162,21 @@ export type PrimerNodeProps = {
   flavor: NodeFlavorTextBody | NodeFlavorPrimBody | NodeFlavorNoBody;
   contents: string;
   hideLabel: boolean;
+  showIDs: boolean;
 };
 
 /** Properties for a simple node. */
 export type PrimerSimpleNodeProps = {
   nodeData: NodeData;
   flavor: NodeFlavorNoBody;
+  showIDs: boolean;
 };
 
 /** Properties for a box node. */
 export type PrimerBoxNodeProps = {
   nodeData: NodeData;
   flavor: NodeFlavorBoxBody;
+  showIDs: boolean;
 };
 
 /** Properties for the special definition name node. */


### PR DESCRIPTION
Discussions in #1005 and #1023 about how to toggle experimental features led me to finally look in to something I've long-thought we could do with: an area in the UI for developers only.

We had something similar in the bottom-right corner in Vonnegut, except that IIRC, while that was only intended for development use, it also appeared in the production build. And I can't remember quite what we actually used it for altogether (I think there was an option to dump a JSON serialisation of the current program?).

We already added a dev-only menu in #1002. But that was specifically for React Query. This PR essentially extends that with a bespoke menu for Primer-specific settings.

For convenience in avoiding potential conflicts, this is currently based on #1023.

Feel free to bikeshed. This is currently just a quick idea without much thought given to the design. Although I haven't marked as a draft, since I do consider it to be in a mergeable state.