### PR TITLE
fix: Add extra padding to kind and definition nodes

### DIFF
--- a/src/components/TreeReactFlow/Types.ts
+++ b/src/components/TreeReactFlow/Types.ts
@@ -134,6 +134,13 @@ export const primerNodeWith = <T>(n: PrimerNode, x: T): PrimerNode<T> =>
     data: { ...n1.data, ...x },
   }))(n);
 
+export type Padding = {
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+};
+
 /** Data corresponding to a node from the backend.
  * This is not used by special nodes, like term definition names or most parts of type definitions,
  * but only in places where the backend allows an arbitrarily nested (term or type) expression.
@@ -203,6 +210,7 @@ export type PrimerTypeDefConsNodeProps = {
 export type PrimerCommonNodeProps = {
   width: number;
   height: number;
+  padding?: Padding;
   selected: boolean;
   style: "inline" | "corner";
 };

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -680,6 +680,18 @@ const makePrimerNode = async (
               ...common,
               // Square, with same height as other nodes.
               width: common.height,
+              ...(flavorSort(flavor) == "kind"
+                ? {
+                    padding: {
+                      // Since these nodes are rotated, their width,
+                      // as reported to the layout engine, is off by a factor of √2.
+                      // We don't pad vertically since allowing some overlap in the y-axis actually looks better,
+                      // due to the rotation and the fact that all non-leaf kind nodes have precisely two children.
+                      left: (common.height * Math.sqrt(2) - common.height) / 2,
+                      right: (common.height * Math.sqrt(2) - common.height) / 2,
+                    },
+                  }
+                : {}),
             },
             zIndex,
           },

--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -50,6 +50,7 @@ import {
   PrimerTypeDefParamNodeProps,
   PrimerTypeDefNameNodeProps,
   NodeData,
+  Padding,
 } from "./Types";
 import { LayoutParams, layoutTree } from "./layoutTree";
 import {
@@ -100,6 +101,7 @@ type NodeParams = {
   nodeWidth: number;
   nodeHeight: number;
   boxPadding: number;
+  defNodePadding: Padding;
   selection?: Selection;
   level: Level;
   showIDs: boolean;
@@ -137,6 +139,7 @@ export const defaultTreeReactFlowProps: Pick<
   nodeHeight: 35,
   boxPadding: 55,
   defParams: { nameNodeMultipliers: { width: 3, height: 2 } },
+  defNodePadding: { bottom: 16 },
   layout: {
     type: WasmLayoutType.Tidy,
     margins: { child: 28, sibling: 18 },
@@ -853,6 +856,7 @@ const defToTree = async (
         contents: { def: def.name },
       }),
       nested: [],
+      padding: p.defNodePadding,
     },
     type: "primer-def-name",
     zIndex: 0,
@@ -1053,6 +1057,7 @@ const typeDefToTree = async (
                   },
                 },
               }),
+              padding: p.defNodePadding,
             },
             zIndex: 0,
           },
@@ -1084,6 +1089,7 @@ const typeDefToTree = async (
           tag: "SelectionTypeDef",
           contents: { def: def.name },
         }),
+        padding: p.defNodePadding,
       },
       zIndex: 0,
     },


### PR DESCRIPTION
The last commit fixes something which would otherwise become a much bigger problem after #1036, since kinds can then be near non-kinds. Although I haven't yet tried combining the changes. It's possible that we would then want to add vertical padding alongside the existing horizontal padding. But this would be trivial to implement now.