### PR TITLE
chore: use Nodejs 18.x for GitHub CI

### DIFF
--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -29,7 +29,10 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3.7.0
         with:
-          node-version-file: package.json
+          node-version: 18.x
+          check-latest: true
+          # Disabled until we can satisfy Tidy.
+          #node-version-file: package.json
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -29,7 +29,10 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3.7.0
         with:
-          node-version-file: package.json
+          node-version: 18.x
+          check-latest: true
+          # Disabled until we can satisfy Tidy.
+          #node-version-file: package.json
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
Tidy doesn't like later versions.

Signed-off-by: Drew Hess <src@drewhess.com>
