### PR TITLE
feat: Add edge labels

### DIFF
--- a/src/components/TreeReactFlow/Types.ts
+++ b/src/components/TreeReactFlow/Types.ts
@@ -1,4 +1,5 @@
 import {
+  EdgeFlavor,
   GlobalName,
   NodeFlavorBoxBody,
   NodeFlavorNoBody,
@@ -229,9 +230,19 @@ export type PrimerEdge = {
   sourceHandle: Position;
   targetHandle: Position;
   zIndex: number;
+  // label?: string;
+  // TODO why? this seems like a bad abstraction
+  // but we can't specify classes in `EdgeBase`
+  // https://github.com/xyflow/xyflow/issues/420
+  // ReactFlow seems to magically make use of this class instead
+  // in _nodes_ we can use classes, since we're not using an equivalent `NodeBase`
+  className: string;
 } & ({ type: "primer"; data: PrimerEdgeProps } | { type: "primer-def" });
 
-export type PrimerEdgeProps = { flavor: NodeFlavor };
+export type PrimerEdgeProps = {
+  flavor: NodeFlavor;
+  edgeFlavor: EdgeFlavor;
+};
 
 export type Positioned<T> = T & {
   position: { x: number; y: number };


### PR DESCRIPTION
Behaviour is probably what we want, but implementation still a little messy.

We only display labels for `let` nodes for now. Eventually we might want to do more with this, including even labelling every single edge in beginner mode.

I had previously thought that labels should be on the outgoing connection rather than the edge itself, out of concern that the latter would look a bit like a node, and as an indication that the number of edges and their names is a property of the parent. But this design, with borderless labels, as iterated on with @dhess last week, actually looks alright.

Closes https://github.com/hackworthltd/primer-app/issues/24, I suppose.