### PR TITLE
feat: render separate binders and names

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-4a105b7c084cdbf599acb2bc5bb9283d0eae46ff
+          image: ghcr.io/hackworthltd/primer-service-dev:git-4d3f7e22e123ebcf3a31d704a518ad443ce29c75
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -341,6 +341,24 @@
         "systems": "systems_3"
       },
       "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
         "lastModified": 1685518550,
         "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
@@ -354,9 +372,9 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_5": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1685518550,
@@ -387,6 +405,25 @@
         "ref": "release/8.6.5-iohk",
         "repo": "ghc",
         "type": "github"
+      }
+    },
+    "ghc-wasm": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1698055010,
+        "narHash": "sha256-OGk0mIHtIbGQi2zON+xqyXAsobSdVMgC/7jcFLvWAMo=",
+        "ref": "refs/heads/master",
+        "rev": "c0aa3bb7d88bb6ec809210e17658dd1ed64ba66c",
+        "revCount": 136,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
       }
     },
     "ghc980": {
@@ -825,7 +862,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -863,7 +900,7 @@
     },
     "nix-darwin_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1696360011,
@@ -1249,6 +1286,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1697723726,
+        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1687274257,
         "narHash": "sha256-TutzPriQcZ8FghDhEolnHcYU2oHIG5XWF+/SUBNnAOE=",
         "path": "/nix/store/22qgs3skscd9bmrxv9xv4q5d4wwm5ppx-source",
@@ -1260,7 +1313,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
@@ -1345,7 +1398,7 @@
     "pre-commit-hooks-nix_3": {
       "inputs": {
         "flake-compat": "flake-compat_7",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "gitignore": "gitignore_4",
         "nixpkgs": [
           "primer",
@@ -1371,7 +1424,7 @@
     "pre-commit-hooks-nix_4": {
       "inputs": {
         "flake-compat": "flake-compat_9",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "gitignore": "gitignore_5",
         "nixpkgs": [
           "primer",
@@ -1397,6 +1450,7 @@
       "inputs": {
         "flake-compat": "flake-compat_5",
         "flake-parts": "flake-parts_3",
+        "ghc-wasm": "ghc-wasm",
         "hacknix": "hacknix_2",
         "haskell-nix": "haskell-nix",
         "nixpkgs": [
@@ -1407,17 +1461,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1700667305,
-        "narHash": "sha256-C6BTQ6G7m6fqqN0wMkG0ApZdoXNd+zO1xDvXkWTSIsY=",
+        "lastModified": 1701344940,
+        "narHash": "sha256-TriygjZfVKDalJN+/4mtYuBiuzQhGVihZ+6V0e/St70=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "4a105b7c084cdbf599acb2bc5bb9283d0eae46ff",
+        "rev": "4d3f7e22e123ebcf3a31d704a518ad443ce29c75",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "4a105b7c084cdbf599acb2bc5bb9283d0eae46ff",
+        "rev": "4d3f7e22e123ebcf3a31d704a518ad443ce29c75",
         "type": "github"
       }
     },
@@ -1498,6 +1552,21 @@
       }
     },
     "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/4a105b7c084cdbf599acb2bc5bb9283d0eae46ff;
+    primer.url = github:hackworthltd/primer/4d3f7e22e123ebcf3a31d704a518ad443ce29c75;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };

--- a/src/components/TreeReactFlow/Flavor.ts
+++ b/src/components/TreeReactFlow/Flavor.ts
@@ -76,13 +76,13 @@ export const flavorClasses = (flavor: NodeFlavor): string =>
           );
         case "Lam":
           return classNames(
-            "border-blue-primary ring-blue-primary bg-white-primary",
+            "border-blue-primary ring-blue-primary bg-blue-primary",
             "hover:ring-blue-primary",
             commonHoverClasses
           );
         case "LAM":
           return classNames(
-            "border-blue-secondary ring-blue-secondary bg-white-primary",
+            "border-blue-secondary ring-blue-secondary bg-blue-secondary",
             "hover:ring-blue-secondary",
             commonHoverClasses
           );
@@ -92,6 +92,7 @@ export const flavorClasses = (flavor: NodeFlavor): string =>
             "hover:ring-blue-quaternary",
             commonHoverClasses
           );
+        case "VarBind":
         case "LocalVar":
           return classNames(
             "border-blue-quaternary ring-blue-quaternary bg-white-primary",
@@ -157,6 +158,7 @@ export const flavorClasses = (flavor: NodeFlavor): string =>
             "hover:ring-blue-primary",
             commonHoverClasses
           );
+        case "TVarBind":
         case "TVar":
           return classNames(
             "border-blue-quaternary ring-blue-quaternary bg-white-primary",
@@ -171,7 +173,7 @@ export const flavorClasses = (flavor: NodeFlavor): string =>
           );
         case "TForall":
           return classNames(
-            "border-blue-secondary ring-blue-secondary bg-white-primary",
+            "border-blue-secondary ring-blue-secondary bg-blue-secondary",
             "hover:ring-blue-secondary",
             commonHoverClasses
           );
@@ -195,12 +197,6 @@ export const flavorClasses = (flavor: NodeFlavor): string =>
           return "border-green-primary ring-green-primary bg-white-primary";
         case "PatternWildcard":
           return "border-none bg-transparent";
-        case "PatternBind":
-          return classNames(
-            "border-blue-quaternary ring-blue-quaternary bg-white-primary",
-            "hover:ring-blue-quaternary",
-            commonHoverClasses
-          );
       }
     })()
   );
@@ -231,11 +227,12 @@ export const flavorContentClasses = (
         case "KFun":
           return "text-white-primary";
         case "Lam":
-          return "text-blue-primary";
+          return "text-white-primary";
         case "LAM":
-          return "text-blue-secondary";
+          return "text-white-primary";
         case "GlobalVar":
           return "text-blue-primary";
+        case "VarBind":
         case "LocalVar":
           return "text-blue-primary";
         case "Let":
@@ -258,12 +255,13 @@ export const flavorContentClasses = (
           return "text-blue-primary";
         case "TFun":
           return "text-white-primary";
+        case "TVarBind":
         case "TVar":
           return "text-blue-primary";
         case "TApp":
           return "text-white-primary";
         case "TForall":
-          return "text-blue-secondary";
+          return "text-white-primary";
         case "TLet":
           return "text-white-primary";
         case "PatternCon":
@@ -275,8 +273,6 @@ export const flavorContentClasses = (
           // respond to Tailwind's font size classes. The `text-grey-secondary` is a
           // backup in case the emoji doesn't render on a particular client.
           return "text-grey-secondary scale-150";
-        case "PatternBind":
-          return "text-blue-primary";
       }
     })()
   );
@@ -310,6 +306,7 @@ export const flavorLabelClasses = (flavor: NodeFlavor): string =>
           return "font-code bg-grey-tertiary bg-grey-tertiary text-white-primary";
         case "KFun":
           return "font-code bg-grey-tertiary bg-grey-tertiary text-white-primary";
+        case "VarBind":
         case "LocalVar":
           return "bg-blue-quaternary border-blue-quaternary text-white-primary";
         case "Let":
@@ -332,6 +329,7 @@ export const flavorLabelClasses = (flavor: NodeFlavor): string =>
           return "bg-green-primary border-green-primary text-white-primary";
         case "TFun":
           return "font-code bg-blue-primary border-blue-primary text-white-primary";
+        case "TVarBind":
         case "TVar":
           return "bg-blue-quaternary border-blue-quaternary text-white-primary";
         case "TApp":
@@ -348,8 +346,6 @@ export const flavorLabelClasses = (flavor: NodeFlavor): string =>
           return "bg-green-primary border-green-primary text-white-primary";
         case "PatternWildcard":
           return "hidden";
-        case "PatternBind":
-          return "bg-blue-quaternary border-blue-quaternary text-white-primary";
       }
     })()
   );
@@ -418,7 +414,9 @@ export const flavorEdgeClasses = (flavor: NodeFlavor): string => {
       return "stroke-green-primary";
     case "PatternWildcard":
       return "stroke-grey-secondary";
-    case "PatternBind":
+    case "VarBind":
+      return "stroke-blue-quaternary";
+    case "TVarBind":
       return "stroke-blue-quaternary";
   }
 };
@@ -481,14 +479,16 @@ export const flavorLabel = (flavor: NodeFlavor): string => {
       return "V";
     case "PatternWildcard":
       return "🤷🏽‍♀️";
-    case "PatternBind":
-      return "Var";
     case "KType":
       return "✱";
     case "KHole":
       return "?";
     case "KFun":
       return "➜";
+    case "VarBind":
+      return "bind";
+    case "TVarBind":
+      return "type bind";
   }
 };
 
@@ -498,21 +498,14 @@ export const flavorLabel = (flavor: NodeFlavor): string => {
  */
 export const flavorIsSyntax = (flavor: NodeFlavorTextBody): boolean => {
   switch (flavor) {
-    case "Lam":
-    case "LAM":
-    case "Let":
-    case "LetType":
-    case "Letrec":
-    case "TForall":
-    case "TLet":
-      return true;
     case "Con":
     case "GlobalVar":
     case "LocalVar":
     case "TCon":
     case "TVar":
     case "PatternCon":
-    case "PatternBind":
+    case "VarBind":
+    case "TVarBind":
       return false;
   }
 };
@@ -549,6 +542,20 @@ export const noBodyFlavorContents = (flavor: NodeFlavorNoBody): string => {
       return "kind hole";
     case "KFun":
       return "type constructor";
+    case "LAM":
+      return "type lambda";
+    case "Lam":
+      return "lambda";
+    case "Let":
+      return "let";
+    case "LetType":
+      return "let type";
+    case "Letrec":
+      return "recursive let";
+    case "TForall":
+      return "forall";
+    case "TLet":
+      return "type let";
   }
 };
 
@@ -570,7 +577,6 @@ export const flavorSort = (flavor: NodeFlavor): "term" | "type" | "kind" => {
     case "LAM":
     case "Let":
     case "Letrec":
-    case "PatternBind":
     case "PatternCon":
     case "LetType":
     case "GlobalVar":
@@ -586,6 +592,7 @@ export const flavorSort = (flavor: NodeFlavor): "term" | "type" | "kind" => {
     case "CaseWith":
     case "PatternWildcard":
     case "PrimPattern":
+    case "VarBind":
       return "term";
     case "TCon":
     case "TVar":
@@ -595,6 +602,7 @@ export const flavorSort = (flavor: NodeFlavor): "term" | "type" | "kind" => {
     case "THole":
     case "TFun":
     case "TApp":
+    case "TVarBind":
       return "type";
     case "KFun":
     case "KHole":

--- a/src/components/examples/trees.ts
+++ b/src/components/examples/trees.ts
@@ -14,7 +14,24 @@ export const tree1: Tree = {
 };
 
 export const tree2: Tree = {
-  body: { tag: "TextBody", contents: { fst: "Lam", snd: { baseName: "x" } } },
+  body: {
+    tag: "NoBody",
+    contents: "Lam",
+  },
+  rightChild: {
+    fst: "Bind",
+    snd: {
+      nodeId: "202",
+      body: {
+        tag: "TextBody",
+        contents: {
+          fst: "LocalVar",
+          snd: { baseName: "x" },
+        },
+      },
+      childTrees: [],
+    },
+  },
   childTrees: [
     {
       fst: "Hole",
@@ -33,8 +50,19 @@ export const tree2: Tree = {
 
 export const tree3: Tree = {
   body: {
-    tag: "TextBody",
-    contents: { fst: "Lam", snd: { baseName: "y" } },
+    tag: "NoBody",
+    contents: "Lam",
+  },
+  rightChild: {
+    fst: "Bind",
+    snd: {
+      nodeId: "302",
+      body: {
+        tag: "TextBody",
+        contents: { fst: "VarBind", snd: { baseName: "y" } },
+      },
+      childTrees: [],
+    },
   },
   childTrees: [
     {
@@ -64,16 +92,38 @@ export const tree4: Tree = {
             fst: "Hole",
             snd: {
               body: {
-                tag: "TextBody",
-                contents: { fst: "LAM", snd: { baseName: "a" } },
+                tag: "NoBody",
+                contents: "LAM",
+              },
+              rightChild: {
+                fst: "Bind",
+                snd: {
+                  nodeId: "410",
+                  body: {
+                    tag: "TextBody",
+                    contents: { fst: "VarBind", snd: { baseName: "a" } },
+                  },
+                  childTrees: [],
+                },
               },
               childTrees: [
                 {
                   fst: "Hole",
                   snd: {
                     body: {
-                      tag: "TextBody",
-                      contents: { fst: "Lam", snd: { baseName: "x" } },
+                      tag: "NoBody",
+                      contents: "Lam",
+                    },
+                    rightChild: {
+                      fst: "Bind",
+                      snd: {
+                        nodeId: "411",
+                        body: {
+                          tag: "TextBody",
+                          contents: { fst: "VarBind", snd: { baseName: "x" } },
+                        },
+                        childTrees: [],
+                      },
                     },
                     childTrees: [
                       {
@@ -102,8 +152,19 @@ export const tree4: Tree = {
             fst: "Hole",
             snd: {
               body: {
-                tag: "TextBody",
-                contents: { fst: "TForall", snd: { baseName: "a" } },
+                tag: "NoBody",
+                contents: "TForall",
+              },
+              rightChild: {
+                fst: "Bind",
+                snd: {
+                  nodeId: "412",
+                  body: {
+                    tag: "TextBody",
+                    contents: { fst: "VarBind", snd: { baseName: "a" } },
+                  },
+                  childTrees: [],
+                },
               },
               childTrees: [
                 {
@@ -162,8 +223,19 @@ export const tree4: Tree = {
 
 export const tree5: Tree = {
   body: {
-    tag: "TextBody",
-    contents: { fst: "Lam", snd: { baseName: "x" } },
+    tag: "NoBody",
+    contents: "Lam",
+  },
+  rightChild: {
+    fst: "Bind",
+    snd: {
+      nodeId: "507",
+      body: {
+        tag: "TextBody",
+        contents: { fst: "VarBind", snd: { baseName: "x" } },
+      },
+      childTrees: [],
+    },
   },
   childTrees: [
     {
@@ -208,10 +280,21 @@ export const tree5: Tree = {
 
 export const tree6: Tree = {
   body: {
-    tag: "TextBody",
-    contents: {
-      fst: "Lam",
-      snd: { baseName: "a very very very long variable name" },
+    tag: "NoBody",
+    contents: "Lam",
+  },
+  rightChild: {
+    fst: "Bind",
+    snd: {
+      nodeId: "607",
+      body: {
+        tag: "TextBody",
+        contents: {
+          fst: "VarBind",
+          snd: { baseName: "a very very very long variable name" },
+        },
+      },
+      childTrees: [],
     },
   },
   childTrees: [
@@ -263,8 +346,19 @@ export const oddEvenTrees: [string, Tree][] = [
     "even",
     {
       body: {
-        contents: { fst: "Lam", snd: { baseName: "x" } },
-        tag: "TextBody",
+        tag: "NoBody",
+        contents: "Lam",
+      },
+      rightChild: {
+        fst: "Bind",
+        snd: {
+          nodeId: "bind1",
+          body: {
+            tag: "TextBody",
+            contents: { fst: "VarBind", snd: { baseName: "x" } },
+          },
+          childTrees: [],
+        },
       },
       childTrees: [
         {
@@ -364,7 +458,7 @@ export const oddEvenTrees: [string, Tree][] = [
                                   snd: {
                                     body: {
                                       contents: {
-                                        fst: "PatternBind",
+                                        fst: "VarBind",
                                         snd: { baseName: "n" },
                                       },
                                       tag: "TextBody",
@@ -555,8 +649,19 @@ export const oddEvenTrees: [string, Tree][] = [
     "odd",
     {
       body: {
-        contents: { fst: "Lam", snd: { baseName: "x" } },
-        tag: "TextBody",
+        tag: "NoBody",
+        contents: "Lam",
+      },
+      rightChild: {
+        fst: "Bind",
+        snd: {
+          nodeId: "bind2",
+          body: {
+            tag: "TextBody",
+            contents: { fst: "VarBind", snd: { baseName: "x" } },
+          },
+          childTrees: [],
+        },
       },
       childTrees: [
         {
@@ -648,7 +753,7 @@ export const oddEvenTrees: [string, Tree][] = [
                                   snd: {
                                     body: {
                                       contents: {
-                                        fst: "PatternBind",
+                                        fst: "VarBind",
                                         snd: { baseName: "n" },
                                       },
                                       tag: "TextBody",
@@ -727,8 +832,19 @@ export const oddEvenTreesMiscStyles: [string, Tree][] = [
     "even",
     {
       body: {
-        contents: { fst: "Lam", snd: { baseName: "x" } },
-        tag: "TextBody",
+        tag: "NoBody",
+        contents: "Lam",
+      },
+      rightChild: {
+        fst: "Bind",
+        snd: {
+          nodeId: "bind1",
+          body: {
+            tag: "TextBody",
+            contents: { fst: "VarBind", snd: { baseName: "x" } },
+          },
+          childTrees: [],
+        },
       },
       childTrees: [
         {
@@ -815,7 +931,7 @@ export const oddEvenTreesMiscStyles: [string, Tree][] = [
                               snd: {
                                 body: {
                                   contents: {
-                                    fst: "PatternBind",
+                                    fst: "VarBind",
                                     snd: { baseName: "n" },
                                   },
                                   tag: "TextBody",
@@ -1002,8 +1118,19 @@ export const oddEvenTreesMiscStyles: [string, Tree][] = [
     "odd",
     {
       body: {
-        contents: { fst: "Lam", snd: { baseName: "x" } },
-        tag: "TextBody",
+        tag: "NoBody",
+        contents: "Lam",
+      },
+      rightChild: {
+        fst: "Bind",
+        snd: {
+          nodeId: "bind2",
+          body: {
+            tag: "TextBody",
+            contents: { fst: "VarBind", snd: { baseName: "x" } },
+          },
+          childTrees: [],
+        },
       },
       childTrees: [
         {
@@ -1090,7 +1217,7 @@ export const oddEvenTreesMiscStyles: [string, Tree][] = [
                               snd: {
                                 body: {
                                   contents: {
-                                    fst: "PatternBind",
+                                    fst: "VarBind",
                                     snd: { baseName: "n" },
                                   },
                                   tag: "TextBody",

--- a/src/primer-api/model/edgeFlavor.ts
+++ b/src/primer-api/model/edgeFlavor.ts
@@ -27,4 +27,5 @@ export const EdgeFlavor = {
   FunOut: 'FunOut',
   ForallKind: 'ForallKind',
   Forall: 'Forall',
+  Bind: 'Bind',
 } as const;

--- a/src/primer-api/model/nodeFlavorNoBody.ts
+++ b/src/primer-api/model/nodeFlavorNoBody.ts
@@ -26,4 +26,11 @@ export const NodeFlavorNoBody = {
   KType: 'KType',
   KHole: 'KHole',
   KFun: 'KFun',
+  Lam: 'Lam',
+  LAM: 'LAM',
+  Let: 'Let',
+  LetType: 'LetType',
+  Letrec: 'Letrec',
+  TLet: 'TLet',
+  TForall: 'TForall',
 } as const;

--- a/src/primer-api/model/nodeFlavorTextBody.ts
+++ b/src/primer-api/model/nodeFlavorTextBody.ts
@@ -12,17 +12,11 @@ export type NodeFlavorTextBody = typeof NodeFlavorTextBody[keyof typeof NodeFlav
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const NodeFlavorTextBody = {
   Con: 'Con',
-  Lam: 'Lam',
-  LAM: 'LAM',
-  Let: 'Let',
-  LetType: 'LetType',
-  Letrec: 'Letrec',
-  PatternBind: 'PatternBind',
   PatternCon: 'PatternCon',
   TCon: 'TCon',
   TVar: 'TVar',
-  TForall: 'TForall',
-  TLet: 'TLet',
   GlobalVar: 'GlobalVar',
   LocalVar: 'LocalVar',
+  VarBind: 'VarBind',
+  TVarBind: 'TVarBind',
 } as const;


### PR DESCRIPTION
This PR corresponds to the backend PR https://github.com/hackworthltd/primer/pull/1183.

As noted in that backend PR, we cannot yet select the name nodes. We want to enable this, but it'll take some additional backend work. See https://github.com/hackworthltd/primer/issues/75 and https://github.com/hackworthltd/primer/issues/93.