### PR TITLE
chore(typescript): disable `exactOptionalPropertyTypes`

### DIFF
--- a/src/components/TreeReactFlow/index.tsx
+++ b/src/components/TreeReactFlow/index.tsx
@@ -1415,7 +1415,7 @@ export const ReactFlowSafe = <
         // the tree in order to perform actions on them.
         elementsSelectable: false,
         onNodeClick: (e, n) => {
-          "onNodeClick" in p &&
+          p.onNodeClick &&
             p.onNodeClick(
               e,
               // This cast is safe because `N` is also the type of elements of the `nodes` field.

--- a/src/primer-api/primer-api.ts
+++ b/src/primer-api/primer-api.ts
@@ -118,7 +118,7 @@ export const useGetSessionListHook = () => {
 ) => {
         return getSessionList(
           {url: `/openapi/sessions`, method: 'GET',
-        params, ...(signal ? { signal }: {})
+        params, signal
     },
           );
         }
@@ -701,7 +701,7 @@ export const useGetSessionNameHook = () => {
  signal?: AbortSignal
 ) => {
         return getSessionName(
-          {url: `/openapi/sessions/${sessionId}/name`, method: 'GET', ...(signal ? { signal }: {})
+          {url: `/openapi/sessions/${sessionId}/name`, method: 'GET', signal
     },
           );
         }
@@ -827,7 +827,7 @@ export const useGetProgramHook = () => {
  signal?: AbortSignal
 ) => {
         return getProgram(
-          {url: `/openapi/sessions/${sessionId}/program`, method: 'GET', ...(signal ? { signal }: {})
+          {url: `/openapi/sessions/${sessionId}/program`, method: 'GET', signal
     },
           );
         }
@@ -1129,7 +1129,7 @@ export const useGetVersionHook = () => {
  signal?: AbortSignal
 ) => {
         return getVersion(
-          {url: `/openapi/version`, method: 'GET', ...(signal ? { signal }: {})
+          {url: `/openapi/version`, method: 'GET', signal
     },
           );
         }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
-    "exactOptionalPropertyTypes": true,
+    "exactOptionalPropertyTypes": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
This setting is causing problems for us with one package we'd like to use:

https://github.com/hackworthltd/primer-app/pull/1012#issuecomment-1633324926

and is also preventing us from migrating to TypeScript 5 due to an upstream issue in `react-router` that's been unaddressed for almost a year:

https://github.com/hackworthltd/primer-app/issues/898

There were no objections to disabling it, so we do so in this commit. (There is one minor code change required as a result, just an additional optional property check on a `onNodeClick` handler in our React Flow wrapper.)

Closes https://github.com/hackworthltd/primer-app/issues/898