### PR TITLE
chore: bump Primer pin to latest `main`

### DIFF
--- a/argocd/base/statefulset.yaml
+++ b/argocd/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           # Note: use the *dev* version of the package here, so that
           # PRs can deploy `primer-service` container images that have
           # not yet been merged to `primer` `main`.
-          image: ghcr.io/hackworthltd/primer-service-dev:git-a9ce4eca8b3e201ff8339d4d7dd7182e82c2cf23
+          image: ghcr.io/hackworthltd/primer-service-dev:git-17171c78abafc8c46e2eea69109320f90e06a6ab
           ports:
             - containerPort: 8081
           env:

--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1711947426,
-        "narHash": "sha256-dIWf+sQHoMD3Quy3Qrc88g7CXY9OiqOVSA6PPJjl7cM=",
+        "lastModified": 1712545072,
+        "narHash": "sha256-vb/6GtGmp/7wM74vEi7z1VmD9Tb0NWqVMIETf2bDoX8=",
         "ref": "refs/heads/master",
-        "rev": "838f6b1712a1c80b9ba3ebac3afd6f70f222cb6c",
-        "revCount": 158,
+        "rev": "48ecacd922638487f65981c0018044b55dc7feb9",
+        "revCount": 160,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc-wasm-meta"
       },
@@ -606,11 +606,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1712449532,
-        "narHash": "sha256-scbBPqo1x6/jNMdm5qAsXhLykziRRyP8NX6/iY21dos=",
+        "lastModified": 1712967738,
+        "narHash": "sha256-jKx8KJxGHfdmFB2spyj58Na31cknm2RQWvo19vslF6U=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "307472a2ac8b8cc7258a415b1c15b251b5f0d88d",
+        "rev": "c3ab2f880ee6c8af1f51e5e5202e96a29144a953",
         "type": "github"
       },
       "original": {
@@ -659,11 +659,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1712336319,
-        "narHash": "sha256-SctkQIFUIW0VI3YDRJsoHOHmEAuiTcGB0EUl+yyVfyQ=",
+        "lastModified": 1712612784,
+        "narHash": "sha256-HPbFvSudO7iBwdn2VK9Gy1AV7klzgq7BmYJnH7yrMqU=",
         "owner": "hackworthltd",
         "repo": "hacknix",
-        "rev": "e16b33b931ca4991b7be2eb6976b8f66fef29ab3",
+        "rev": "eb217ef5356c58424848dac21249f543882e8b49",
         "type": "github"
       },
       "original": {
@@ -711,11 +711,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1712451016,
-        "narHash": "sha256-sKUl99brqbRBOgFr6SeLZn6VI4q1HmjBDoIEz7wMXvI=",
+        "lastModified": 1712969356,
+        "narHash": "sha256-d0syrqLiyhwuOA8dAWHZ0N8NNI51JvhtXySQYt2XvAQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "afa6a504aa525bdfb31a682a55d29492a55bcb64",
+        "rev": "7400a707f2363fcb0dd9f3066672bbbad6976bb9",
         "type": "github"
       },
       "original": {
@@ -1376,11 +1376,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1712439257,
+        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
         "type": "github"
       },
       "original": {
@@ -1553,17 +1553,17 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1712615328,
-        "narHash": "sha256-U5Zmakv4qQ3AdtCyHcyB+gbeAp6cS0wFFwrmG1RrsTI=",
+        "lastModified": 1713405384,
+        "narHash": "sha256-QXFgiiT9WZOpCUqNKRwqtiUympzwgXdE9fFPQOw5Nhs=",
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "a9ce4eca8b3e201ff8339d4d7dd7182e82c2cf23",
+        "rev": "17171c78abafc8c46e2eea69109320f90e06a6ab",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
         "repo": "primer",
-        "rev": "a9ce4eca8b3e201ff8339d4d7dd7182e82c2cf23",
+        "rev": "17171c78abafc8c46e2eea69109320f90e06a6ab",
         "type": "github"
       }
     },
@@ -1585,11 +1585,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1712448691,
-        "narHash": "sha256-eRaWJjAvNr0hpIT2XZ/sFF+WIwpJNW4or/q9QDCIunI=",
+        "lastModified": 1712966994,
+        "narHash": "sha256-0MMsCMyHDO1jv/DZC+g3rcNTNk/zfE9oeHTlM/rU4MU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "bdecf25189e83a178b90be3f9a11502de35a3315",
+        "rev": "5964d4ef5062c2530502330605200796801a1052",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
 
     # Note: don't override any of primer's Nix flake inputs, or else
     # we won't hit its binary cache.
-    primer.url = github:hackworthltd/primer/a9ce4eca8b3e201ff8339d4d7dd7182e82c2cf23;
+    primer.url = github:hackworthltd/primer/17171c78abafc8c46e2eea69109320f90e06a6ab;
 
     flake-parts.url = "github:hercules-ci/flake-parts";
   };


### PR DESCRIPTION
This bump includes the change where the backend runs evaluations outside `STM`.